### PR TITLE
[회고글] 상세페이지 및 response Date type 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 	implementation 'org.slf4j:slf4j-api'
+	implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.3'
 
 
 	//oauth2, security, jwt

--- a/src/main/java/com/yapp18/retrospect/service/PostService.java
+++ b/src/main/java/com/yapp18/retrospect/service/PostService.java
@@ -58,7 +58,7 @@ public class PostService {
 
     // 회고글 카테고리 검색
     public ApiPagingResultResponse<PostDto.ListResponse> getPostsListByContents(String category, String order, Long cursorId, Integer pageSize){
-        List<PostDto.ListResponse> result = new ArrayList<>();
+        List<PostDto.ListResponse> result;
         if (order.equals("recent")){
             Post post = findRecentPost(cursorId);
             result = postQueryRepository.findByCategory(cursorId, pageSize,post.getCreated_at(), category); // 최신순+카테고리  검색
@@ -74,7 +74,8 @@ public class PostService {
     // 회고글 상세페이지
     public PostDto.detailResponse findPostContents(Long postIdx){
         Post post = postRepository.findById(postIdx).orElseThrow(() -> new NullPointerException("해당 post_idx가 없습니다."));
-        List<String> tag = tagRepository.findByPostPostIdx(postIdx).stream()
+        List<String> tag = tagRepository.findByPostPostIdx(postIdx)
+                .stream()
                 .map(Tag::getTag)
                 .collect(Collectors.toList());
         return new PostDto.detailResponse(post, tag);
@@ -159,5 +160,8 @@ public class PostService {
         }
         return postRepository.findById(cursorId).orElseThrow(() -> new NullPointerException("해당 회고글 idx가 없습니다."));
     }
+
+
+
 
 }

--- a/src/main/java/com/yapp18/retrospect/service/PostService.java
+++ b/src/main/java/com/yapp18/retrospect/service/PostService.java
@@ -72,13 +72,14 @@ public class PostService {
     }
 
     // 회고글 상세페이지
-    public PostDto.detailResponse findPostContents(Long postIdx){
+    public PostDto.detailResponse findPostContents(Long postIdx, Long userIdx){
         Post post = postRepository.findById(postIdx).orElseThrow(() -> new NullPointerException("해당 post_idx가 없습니다."));
         List<String> tag = tagRepository.findByPostPostIdx(postIdx)
                 .stream()
                 .map(Tag::getTag)
                 .collect(Collectors.toList());
-        return new PostDto.detailResponse(post, tag);
+        boolean writer = userIdx != 0 && isWriter(post.getUser().getUserIdx(), userIdx);
+        return new PostDto.detailResponse(post, tag, writer);
     }
 
 
@@ -161,7 +162,8 @@ public class PostService {
         return postRepository.findById(cursorId).orElseThrow(() -> new NullPointerException("해당 회고글 idx가 없습니다."));
     }
 
-
-
+    private boolean isWriter(Long postUserIdx,Long userIdx){
+        return postUserIdx.equals(userIdx);
+    }
 
 }

--- a/src/main/java/com/yapp18/retrospect/web/controller/PostController.java
+++ b/src/main/java/com/yapp18/retrospect/web/controller/PostController.java
@@ -50,9 +50,11 @@ public class PostController {
 
     @ApiOperation(value = "detail", notes = "[상세] 회고글 상세보기")
     @GetMapping("/{postIdx}")
-    public ResponseEntity<Object> findPostsContentById(@ApiParam(value = "상세보기 post_idx", required = true, example = "3")
+    public ResponseEntity<Object> findPostsContentById(HttpServletRequest request,
+                                                       @ApiParam(value = "상세보기 post_idx", required = true, example = "3")
                                                        @PathVariable(value = "postIdx") Long postIdx) {
-        PostDto.detailResponse post = postService.findPostContents(postIdx);
+        Long userIdx = (tokenService.getTokenFromRequest(request) != null) ? tokenService.getUserIdx(tokenService.getTokenFromRequest(request)) : 0L;
+        PostDto.detailResponse post = postService.findPostContents(postIdx, userIdx);
         return new ResponseEntity<>(ApiDefaultResponse.res(200,ResponseMessage.POST_DETAIL.getResponseMessage(),post), HttpStatus.OK);
     }
 

--- a/src/main/java/com/yapp18/retrospect/web/dto/PostDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/PostDto.java
@@ -1,5 +1,6 @@
 package com.yapp18.retrospect.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.annotations.QueryProjection;
 import com.yapp18.retrospect.domain.post.Post;
@@ -10,6 +11,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+import springfox.documentation.spring.web.json.Json;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -92,6 +95,7 @@ public class PostDto {
         @ApiModelProperty(value = "조회수")
         private int view;
 
+        @JsonFormat(pattern = "MMM dd, yyyy", locale = "en_GB")
         @ApiModelProperty(value = "생성날짜")
         private LocalDateTime created_at;
 
@@ -170,6 +174,7 @@ public class PostDto {
         @ApiModelProperty(value = "조회수")
         private int view;
 
+        @JsonFormat(pattern = "MMM dd,yyyy",locale = "en_GB")
         @ApiModelProperty(value = "생성날짜")
         private LocalDateTime created_at;
 

--- a/src/main/java/com/yapp18/retrospect/web/dto/PostDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/PostDto.java
@@ -178,11 +178,14 @@ public class PostDto {
         @ApiModelProperty(value = "생성날짜")
         private LocalDateTime created_at;
 
+        @ApiModelProperty(value ="작성자 판단")
+        private boolean isWriter;
+
 //        @ApiModelProperty(value = "댓글 수")
 //        private Long commentCnt;
 
         @Builder
-        public detailResponse(Post post, List<String> tag){
+        public detailResponse(Post post, List<String> tag, boolean isWriter){
             this.postIdx = post.getPostIdx();
             this.title = post.getTitle();
             this.category = post.getCategory();
@@ -192,6 +195,7 @@ public class PostDto {
             this.tag = tag;
             this.view = post.getView();
             this.created_at = post.getCreated_at();
+            this.isWriter = isWriter;
         }
     }
 


### PR DESCRIPTION
- 현재 DB에서 가져온 값은 LocalDateTime 형식으로, 프론트에게 'Oct 22, 2021'  과 같은 timestamp 형태로 전달하기 위해
@JsonFormat 을 DTO에 붙여서 형식을 변환해주었습니다.

- 상세페이지 조회 시 "작성자" 일 때만 "수정, 삭제" 버튼이 화면에 나타나야 하기 때문에 "작성자 판단"해서 boolean으로 반환하는 로직을 추가하였습니다.
request에서 token이 없거나 + token이 있고 post의 작성자와 비교했을 때 token userIdx 값이 다르면 false
token이 있고 post 작성자와 token userIdx 값이 같다면 true입니다.
