### PR TITLE
Add : 댓글 기본 CRUD, 에러 핸들러 추가

### DIFF
--- a/src/main/java/com/yapp18/retrospect/config/ErrorMessage.java
+++ b/src/main/java/com/yapp18/retrospect/config/ErrorMessage.java
@@ -1,0 +1,19 @@
+package com.yapp18.retrospect.config;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorMessage {
+    USER_NULL("존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+    POST_NULL("존재하지 않는 게시물입니다.", HttpStatus.NOT_FOUND),
+    COMMENT_NULL("존재하지 않는 댓글입니다.", HttpStatus.NOT_FOUND);
+
+    private final String errorMessage;
+    private final HttpStatus statusCode;
+
+    ErrorMessage(String errorMessage, HttpStatus statusCode) {
+        this.errorMessage = errorMessage;
+        this.statusCode = statusCode;
+    }
+}

--- a/src/main/java/com/yapp18/retrospect/config/ResponseMessage.java
+++ b/src/main/java/com/yapp18/retrospect/config/ResponseMessage.java
@@ -29,7 +29,11 @@ public enum ResponseMessage {
     TEMPLATE_FIND("템플릿 조회 성공 "),
     NICKNAME_FIND("닉네임 중복 여부 조회 성공 (중복됨 = true)"),
 
-    COMMENT_FIND_POSTIDX("회고 글에 작성된 댓글 조회 성공");
+    COMMENT_DETAIL("댓글 상세 조회 성공"),
+    COMMENT_SAVE("댓글 작성 성공"),
+    COMMENT_UPDATE("댓글 수정 성공"),
+    COMMENT_DELETE("댓글 삭제 성공"),
+    COMMENT_FIND_POSTIDX("회고글에 달린 댓글 리스트 조회 성공");
 
     private final String ResponseMessage;
 

--- a/src/main/java/com/yapp18/retrospect/config/ResponseMessage.java
+++ b/src/main/java/com/yapp18/retrospect/config/ResponseMessage.java
@@ -27,7 +27,9 @@ public enum ResponseMessage {
     AUTH_ISSUE("Access Token 발급 성공"),
     AUTH_REISSUE("Access Token 재발급 성공"),
     TEMPLATE_FIND("템플릿 조회 성공 "),
-    NICKNAME_FIND("닉네임 중복 여부 조회 성공 (중복됨 = true)");
+    NICKNAME_FIND("닉네임 중복 여부 조회 성공 (중복됨 = true)"),
+
+    COMMENT_FIND_POSTIDX("회고 글에 작성된 댓글 조회 성공");
 
     private final String ResponseMessage;
 

--- a/src/main/java/com/yapp18/retrospect/domain/comment/Comment.java
+++ b/src/main/java/com/yapp18/retrospect/domain/comment/Comment.java
@@ -3,6 +3,7 @@ package com.yapp18.retrospect.domain.comment;
 import com.yapp18.retrospect.domain.BaseTimeEntity;
 import com.yapp18.retrospect.domain.post.Post;
 import com.yapp18.retrospect.domain.user.User;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,5 +30,11 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "user_idx")
     private User user;
 
-
+    @Builder
+    public Comment(Long commentIdx, String comment, Post post, User user) {
+        this.commentIdx = commentIdx;
+        this.comment = comment;
+        this.post = post;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/yapp18/retrospect/domain/comment/Comment.java
+++ b/src/main/java/com/yapp18/retrospect/domain/comment/Comment.java
@@ -37,4 +37,21 @@ public class Comment extends BaseTimeEntity {
         this.post = post;
         this.user = user;
     }
+
+    public Comment update(String comments, Post post, User user) {
+        this.comments = comments;
+        this.post = post;
+        this.user = user;
+
+        return this;
+    }
+
+    public Comment update(Comment com) {
+        this.commentIdx = com.getCommentIdx();
+        this.comments = com.getComments();
+        this.post = com.getPost();
+        this.user = com.getUser();
+
+        return this;
+    }
 }

--- a/src/main/java/com/yapp18/retrospect/domain/comment/Comment.java
+++ b/src/main/java/com/yapp18/retrospect/domain/comment/Comment.java
@@ -20,7 +20,7 @@ public class Comment extends BaseTimeEntity {
     private Long commentIdx;
 
     @Column(nullable = false)
-    private String comment;
+    private String comments;
 
     @ManyToOne
     @JoinColumn(name = "post_idx")
@@ -31,9 +31,9 @@ public class Comment extends BaseTimeEntity {
     private User user;
 
     @Builder
-    public Comment(Long commentIdx, String comment, Post post, User user) {
+    public Comment(Long commentIdx, String comments, Post post, User user) {
         this.commentIdx = commentIdx;
-        this.comment = comment;
+        this.comments = comments;
         this.post = post;
         this.user = user;
     }

--- a/src/main/java/com/yapp18/retrospect/domain/comment/CommentRepository.java
+++ b/src/main/java/com/yapp18/retrospect/domain/comment/CommentRepository.java
@@ -1,6 +1,16 @@
 package com.yapp18.retrospect.domain.comment;
 
+import com.yapp18.retrospect.domain.post.Post;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+//    @Query(value = "SELECT * FROM commnet_tb  WHERE (comment_tb.comment_idx <:cursorId) " +
+//            "ORDER BY comment_tb.created_at, comment_tb.comment_idx", nativeQuery = true)
+//    List<Comment> findAllByPostIdx(Long postIdx, Pageable page);
 }

--- a/src/main/java/com/yapp18/retrospect/domain/comment/CommentRepository.java
+++ b/src/main/java/com/yapp18/retrospect/domain/comment/CommentRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-//    @Query(value = "SELECT * FROM commnet_tb  WHERE (comment_tb.comment_idx <:cursorId) " +
-//            "ORDER BY comment_tb.created_at, comment_tb.comment_idx", nativeQuery = true)
-//    List<Comment> findAllByPostIdx(Long postIdx, Pageable page);
+    @Query(value = "SELECT * FROM comment_tb  WHERE (comment_tb.post_idx =:postIdx) " +
+            "ORDER BY comment_tb.created_at", nativeQuery = true)
+    List<Comment> findAllByPost(Long postIdx, Pageable page);
 }

--- a/src/main/java/com/yapp18/retrospect/domain/comment/CommentRepository.java
+++ b/src/main/java/com/yapp18/retrospect/domain/comment/CommentRepository.java
@@ -12,5 +12,5 @@ import java.util.Optional;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query(value = "SELECT * FROM comment_tb  WHERE (comment_tb.post_idx =:postIdx) " +
             "ORDER BY comment_tb.created_at", nativeQuery = true)
-    List<Comment> findAllByPost(Long postIdx, Pageable page);
+    Optional<List<Comment>> findAllByPost(Long postIdx, Pageable page);
 }

--- a/src/main/java/com/yapp18/retrospect/domain/post/PostRepository.java
+++ b/src/main/java/com/yapp18/retrospect/domain/post/PostRepository.java
@@ -1,20 +1,22 @@
 package com.yapp18.retrospect.domain.post;
 
-import ch.qos.logback.classic.db.names.TableName;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface  PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findByPostIdx(Long postIdx);
+
     boolean existsByPostIdxLessThan(Long cursorId);
 
     List<Post> findAllByUserUserIdxOrderByCreatedAtDesc(Long userIdx);
 
     // 쓴 날짜 찾기
-    Post findCreatedAtByPostIdx(Long PostIdx);
+    Post findCreatedAtByPostIdx(Long postIdx);
     Post findViewByPostIdx(Long postIdx);
 
     // 최신 조회

--- a/src/main/java/com/yapp18/retrospect/mapper/CommentMapper.java
+++ b/src/main/java/com/yapp18/retrospect/mapper/CommentMapper.java
@@ -1,0 +1,16 @@
+package com.yapp18.retrospect.mapper;
+
+import com.yapp18.retrospect.domain.comment.Comment;
+import com.yapp18.retrospect.web.dto.CommentDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring") // 스프링 컨테이너에 객체로 관리
+public interface CommentMapper {
+    CommentMapper instance = Mappers.getMapper(CommentMapper.class);
+
+    CommentDto.ListResponse commentToListResponse(Comment comment);
+
+//    @Mapping(target = "userIdx", expression = "java((long)userIdx)")
+//    Comment commentRequestToEntity(CommentDto.CommentRequest commentRequest, Long userIdx);
+}

--- a/src/main/java/com/yapp18/retrospect/mapper/CommentMapper.java
+++ b/src/main/java/com/yapp18/retrospect/mapper/CommentMapper.java
@@ -9,7 +9,7 @@ import org.mapstruct.factory.Mappers;
 public interface CommentMapper {
     CommentMapper instance = Mappers.getMapper(CommentMapper.class);
 
-    CommentDto.ListResponse commentToListResponse(Comment comment);
+    CommentDto.CommentResponse commentToListResponse(Comment comment);
 
 //    @Mapping(target = "userIdx", expression = "java((long)userIdx)")
 //    Comment commentRequestToEntity(CommentDto.CommentRequest commentRequest, Long userIdx);

--- a/src/main/java/com/yapp18/retrospect/service/CommentService.java
+++ b/src/main/java/com/yapp18/retrospect/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.yapp18.retrospect.service;
 
+import com.yapp18.retrospect.domain.comment.Comment;
 import com.yapp18.retrospect.domain.comment.CommentRepository;
 import com.yapp18.retrospect.domain.post.Post;
 import com.yapp18.retrospect.domain.post.PostRepository;
@@ -36,15 +37,13 @@ public class CommentService {
         return commentRepository.save(commentRequest.toEntity(user, post)).getCommentIdx();
     }
 
-//    @Transactional(readOnly = true)
-//    public List<CommentDto.ListResponse> getCommmentsListByPostIdx(Long postIdx, Pageable page){
-//        return commentRepository.findAllByPostIdx(postIdx, page)
-//                .stream()
-//                .map(commentMapper::commentToListResponse)
-//                .collect(Collectors.toList());
-//
-//        return new ApiPagingResultResponse<>(isNext(lastIdx),result);
-//    }
+    @Transactional(readOnly = true)
+    public List<CommentDto.ListResponse> getCommmentsListByPostIdx(Long postIdx, Pageable page){
+        return commentRepository.findAllByPost(postIdx, page)
+                .stream()
+                .map(commentMapper::commentToListResponse)
+                .collect(Collectors.toList());
+    }
 
 //    public boolean isNext(Long cursorId){
 //        if (cursorId == null) return false;

--- a/src/main/java/com/yapp18/retrospect/service/CommentService.java
+++ b/src/main/java/com/yapp18/retrospect/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.yapp18.retrospect.service;
 
+import com.yapp18.retrospect.config.ErrorMessage;
 import com.yapp18.retrospect.domain.comment.Comment;
 import com.yapp18.retrospect.domain.comment.CommentRepository;
 import com.yapp18.retrospect.domain.post.Post;
@@ -7,15 +8,14 @@ import com.yapp18.retrospect.domain.post.PostRepository;
 import com.yapp18.retrospect.domain.user.User;
 import com.yapp18.retrospect.domain.user.UserRepository;
 import com.yapp18.retrospect.mapper.CommentMapper;
+import com.yapp18.retrospect.web.advice.EntityNullException;
 import com.yapp18.retrospect.web.dto.CommentDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -27,26 +27,50 @@ public class CommentService {
     private final CommentMapper commentMapper;
 
     @Transactional
-    public Long inputComments(CommentDto.CommentRequest commentRequest, Long userIdx){
+    public Long inputComments(CommentDto.CommentInputRequest commentInputRequest, Long userIdx){
         User user = userRepository.findByUserIdx(userIdx)
-                .orElseThrow(() -> new NullPointerException("해당 아이디는 없습니다."));
+                .orElseThrow(() -> new EntityNullException(ErrorMessage.USER_NULL));
 
-        Post post = postRepository.findByPostIdx(commentRequest.getPostIdx())
-                .orElseThrow(() -> new NullPointerException("해당 회고글은 없습니다."));
+        Post post = postRepository.findByPostIdx(commentInputRequest.getPostIdx())
+                .orElseThrow(() -> new EntityNullException(ErrorMessage.POST_NULL));
 
-        return commentRepository.save(commentRequest.toEntity(user, post)).getCommentIdx();
+        return commentRepository.save(commentInputRequest.toEntity(post, user)).getCommentIdx();
     }
 
     @Transactional(readOnly = true)
-    public List<CommentDto.ListResponse> getCommmentsListByPostIdx(Long postIdx, Pageable page){
+    public List<CommentDto.CommentResponse> getCommmentsListByPostIdx(Long postIdx, Pageable page){
         return commentRepository.findAllByPost(postIdx, page)
+                .orElseThrow(() ->  new EntityNullException(ErrorMessage.COMMENT_NULL))
                 .stream()
                 .map(commentMapper::commentToListResponse)
                 .collect(Collectors.toList());
     }
 
-//    public boolean isNext(Long cursorId){
-//        if (cursorId == null) return false;
-//        return postRepository.existsByPostIdxLessThan(cursorId);
-//    }
+    @Transactional(readOnly = true)
+    public CommentDto.CommentResponse getCommmentsByIdx(Long commentIdx){
+        return commentRepository.findById(commentIdx)
+                .map(commentMapper::commentToListResponse)
+                .orElseThrow(() ->  new EntityNullException(ErrorMessage.COMMENT_NULL));
+    }
+
+    @Transactional
+    public CommentDto.CommentResponse updateCommentsByIdx(CommentDto.CommentUpdateRequest commentUpdateRequest, Long commentIdx, Long userIdx){
+        User user = userRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new EntityNullException(ErrorMessage.USER_NULL));
+
+        Post post = postRepository.findByPostIdx(commentUpdateRequest.getPostIdx())
+                .orElseThrow(() -> new EntityNullException(ErrorMessage.POST_NULL));
+
+        Comment comment = commentRepository.findById(commentIdx)
+                .map(entity -> entity.update(commentUpdateRequest.getComments(), post, user))
+                .orElse(commentUpdateRequest.toEntity(user, post));
+
+        return commentMapper.commentToListResponse(commentRepository.save(comment));
+    }
+
+    public void deleteCommentsByIdx(Long commentIdx){
+        Comment comment = commentRepository.findById(commentIdx)
+                .orElseThrow(() -> new EntityNullException(ErrorMessage.COMMENT_NULL));
+        commentRepository.delete(comment);
+    }
 }

--- a/src/main/java/com/yapp18/retrospect/service/CommentService.java
+++ b/src/main/java/com/yapp18/retrospect/service/CommentService.java
@@ -1,0 +1,53 @@
+package com.yapp18.retrospect.service;
+
+import com.yapp18.retrospect.domain.comment.CommentRepository;
+import com.yapp18.retrospect.domain.post.Post;
+import com.yapp18.retrospect.domain.post.PostRepository;
+import com.yapp18.retrospect.domain.user.User;
+import com.yapp18.retrospect.domain.user.UserRepository;
+import com.yapp18.retrospect.mapper.CommentMapper;
+import com.yapp18.retrospect.web.dto.CommentDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentMapper commentMapper;
+
+    @Transactional
+    public Long inputComments(CommentDto.CommentRequest commentRequest, Long userIdx){
+        User user = userRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new NullPointerException("해당 아이디는 없습니다."));
+
+        Post post = postRepository.findByPostIdx(commentRequest.getPostIdx())
+                .orElseThrow(() -> new NullPointerException("해당 회고글은 없습니다."));
+
+        return commentRepository.save(commentRequest.toEntity(user, post)).getCommentIdx();
+    }
+
+//    @Transactional(readOnly = true)
+//    public List<CommentDto.ListResponse> getCommmentsListByPostIdx(Long postIdx, Pageable page){
+//        return commentRepository.findAllByPostIdx(postIdx, page)
+//                .stream()
+//                .map(commentMapper::commentToListResponse)
+//                .collect(Collectors.toList());
+//
+//        return new ApiPagingResultResponse<>(isNext(lastIdx),result);
+//    }
+
+//    public boolean isNext(Long cursorId){
+//        if (cursorId == null) return false;
+//        return postRepository.existsByPostIdxLessThan(cursorId);
+//    }
+}

--- a/src/main/java/com/yapp18/retrospect/web/advice/ControllerAdvice.java
+++ b/src/main/java/com/yapp18/retrospect/web/advice/ControllerAdvice.java
@@ -1,0 +1,32 @@
+package com.yapp18.retrospect.web.advice;
+
+import com.yapp18.retrospect.config.ResponseMessage;
+import com.yapp18.retrospect.web.dto.ApiDefaultResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+//    @ExceptionHandler(EntityNullException.class)
+//    public ResponseEntity<Object> entityNullExceptionHandler(EntityNullException e) {
+//        return new ResponseEntity<>(ApiDefaultResponse.res(404, e.getMessage()), e.getStatus());
+//    }
+
+    @ExceptionHandler(EntityNullException.class)
+    public ResponseEntity<Object> entityNullExceptionHandler(EntityNullException e) {
+        return new ResponseEntity<>(ApiDefaultResponse.res(404, e.getMessage()), e.getStatus());
+    }
+
+    @ExceptionHandler(RestException.class)
+    public ResponseEntity<Map<String, Object>> restExceptionHandler(RestException e) {
+        Map<String, Object> resBody = new HashMap<>();
+        resBody.put("message", e.getMessage());
+
+        return new ResponseEntity<>(resBody, e.getStatus());
+    }
+}

--- a/src/main/java/com/yapp18/retrospect/web/advice/EntityNullException.java
+++ b/src/main/java/com/yapp18/retrospect/web/advice/EntityNullException.java
@@ -1,0 +1,26 @@
+package com.yapp18.retrospect.web.advice;
+
+import com.yapp18.retrospect.config.ErrorMessage;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class EntityNullException extends NullPointerException {
+    private ErrorMessage errorMessage;
+    private String message;
+    private HttpStatus status;
+
+    public EntityNullException(ErrorMessage errorMessage) {
+        this.errorMessage = errorMessage;
+        this.message = errorMessage.getErrorMessage();
+        this.status = errorMessage.getStatusCode();
+    }
+
+    public EntityNullException(String s, ErrorMessage errorMessage) {
+        super(s);
+        this.errorMessage = errorMessage;
+        this.message = errorMessage.getErrorMessage();
+        this.status = errorMessage.getStatusCode();
+    }
+}

--- a/src/main/java/com/yapp18/retrospect/web/advice/RestException.java
+++ b/src/main/java/com/yapp18/retrospect/web/advice/RestException.java
@@ -1,0 +1,19 @@
+package com.yapp18.retrospect.web.advice;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class RestException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private HttpStatus status;
+    private String message;
+
+    @Builder
+    public RestException(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/yapp18/retrospect/web/controller/CommentController.java
+++ b/src/main/java/com/yapp18/retrospect/web/controller/CommentController.java
@@ -29,15 +29,44 @@ public class CommentController {
     @ApiOperation(value = "comment", notes = "[댓글] 회고글에 댓글 작성") // api tag, 설명
     @PostMapping("")
     public ResponseEntity<Object> inputComments(HttpServletRequest request,
-                                                @RequestBody CommentDto.CommentRequest commentRequest) {
+                                                @RequestBody CommentDto.CommentInputRequest commentInputRequest) {
         Long userIdx = tokenService.getUserIdx(tokenService.getTokenFromRequest(request));
-        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.COMMENT_FIND_POSTIDX.getResponseMessage(),
-                commentService.inputComments(commentRequest, userIdx)), HttpStatus.OK);
+        return new ResponseEntity<>(ApiDefaultResponse.res(201, ResponseMessage.COMMENT_SAVE.getResponseMessage(),
+                commentService.inputComments(commentInputRequest, userIdx)), HttpStatus.CREATED);
+    }
+
+    @ApiOperation(value = "comment", notes = "[댓글] 댓글 상세보기") // api tag, 설명
+    @GetMapping("/{commentIdx}")
+    public ResponseEntity<Object> getCommentsById(@ApiParam(value = "상세보기 comment_idx", required = true, example = "3")
+                                                   @PathVariable(value = "commentIdx") Long commentIdx) {
+        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.COMMENT_DETAIL.getResponseMessage(),
+                commentService.getCommmentsByIdx(commentIdx)), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "comment", notes = "[댓글] 댓글 수정") // api tag, 설명
+    @PutMapping("/{commentIdx}")
+    public ResponseEntity<Object> updateComments(HttpServletRequest request,
+                                                 @RequestBody CommentDto.CommentUpdateRequest commentUpdateRequest,
+                                                 @ApiParam(value = "수정 comment_idx", required = true, example = "3")
+                                                     @PathVariable(value = "commentIdx") Long commentIdx) {
+        Long userIdx = tokenService.getUserIdx(tokenService.getTokenFromRequest(request));
+        return new ResponseEntity<>(ApiDefaultResponse.res(201, ResponseMessage.COMMENT_UPDATE.getResponseMessage(),
+                commentService.updateCommentsByIdx(commentUpdateRequest, commentIdx, userIdx)), HttpStatus.CREATED);
+    }
+
+    @ApiOperation(value = "comment", notes = "[댓글] 댓글 삭제") // api tag, 설명
+    @DeleteMapping("/{commentIdx}")
+    public ResponseEntity<Object> deleteComments(HttpServletRequest request,
+                                                 @ApiParam(value = "수정 comment_idx", required = true, example = "3")
+                                                 @PathVariable(value = "commentIdx") Long commentIdx) {
+        Long userIdx = tokenService.getUserIdx(tokenService.getTokenFromRequest(request));
+        commentService.deleteCommentsByIdx(commentIdx);
+        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.COMMENT_DELETE.getResponseMessage(), commentIdx), HttpStatus.OK);
     }
 
     @ApiOperation(value = "comment", notes = "[댓글] 회고글에 댓글 목록 조회") // api tag, 설명
     @GetMapping("/lists")
-    public ResponseEntity<Object> getCommentsByPostIdx(@ApiParam(value = "post_idx", required = true, example = "20")
+    public ResponseEntity<Object> getCommentsByPostIdx(@ApiParam(value = "회고글 post_idx", required = true, example = "20")
                                                            @RequestParam(value = "postIdx") Long postIdx,
                                                        @RequestParam(value = "page", defaultValue = "0") Integer page,
                                                        @RequestParam(value = "pageSize",defaultValue = "20") Integer pageSize) {

--- a/src/main/java/com/yapp18/retrospect/web/controller/CommentController.java
+++ b/src/main/java/com/yapp18/retrospect/web/controller/CommentController.java
@@ -35,14 +35,14 @@ public class CommentController {
                 commentService.inputComments(commentRequest, userIdx)), HttpStatus.OK);
     }
 
-//    @ApiOperation(value = "comment", notes = "[댓글] 회고글에 댓글 목록 조회") // api tag, 설명
-//    @GetMapping("/lists")
-//    public ResponseEntity<Object> getCommentsByPostIdx(@ApiParam(value = "post_idx", required = true, example = "20")
-//                                                           @RequestParam(value = "postIdx") Long postIdx,
-//                                                       @RequestParam(value = "page", defaultValue = "0") Long page,
-//                                                       @RequestParam(value = "pageSize",defaultValue = "20") Integer pageSize) {
-//        if (pageSize == null) pageSize = DEFAULT_SIZE;
-//        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.COMMENT_FIND_POSTIDX.getResponseMessage(),
-//                commentService.getCommmentsListByPostIdx(page, PageRequest.of(0,pageSize))), HttpStatus.OK);
-//    }
+    @ApiOperation(value = "comment", notes = "[댓글] 회고글에 댓글 목록 조회") // api tag, 설명
+    @GetMapping("/lists")
+    public ResponseEntity<Object> getCommentsByPostIdx(@ApiParam(value = "post_idx", required = true, example = "20")
+                                                           @RequestParam(value = "postIdx") Long postIdx,
+                                                       @RequestParam(value = "page", defaultValue = "0") Integer page,
+                                                       @RequestParam(value = "pageSize",defaultValue = "20") Integer pageSize) {
+        if (pageSize == null) pageSize = DEFAULT_SIZE;
+        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.COMMENT_FIND_POSTIDX.getResponseMessage(),
+                commentService.getCommmentsListByPostIdx(postIdx, PageRequest.of(page, pageSize))), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/yapp18/retrospect/web/controller/CommentController.java
+++ b/src/main/java/com/yapp18/retrospect/web/controller/CommentController.java
@@ -1,0 +1,48 @@
+package com.yapp18.retrospect.web.controller;
+
+import com.yapp18.retrospect.config.ResponseMessage;
+import com.yapp18.retrospect.service.CommentService;
+import com.yapp18.retrospect.service.TokenService;
+import com.yapp18.retrospect.web.dto.ApiDefaultResponse;
+import com.yapp18.retrospect.web.dto.CommentDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RequiredArgsConstructor
+@RestController
+@Api(value = "CommentController") // swagger 리소스 명시
+@RequestMapping("/api/v2/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+    private final TokenService tokenService;
+    private static final int DEFAULT_SIZE = 20;
+
+    @ApiOperation(value = "comment", notes = "[댓글] 회고글에 댓글 작성") // api tag, 설명
+    @PostMapping("")
+    public ResponseEntity<Object> inputComments(HttpServletRequest request,
+                                                @RequestBody CommentDto.CommentRequest commentRequest) {
+        Long userIdx = tokenService.getUserIdx(tokenService.getTokenFromRequest(request));
+        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.COMMENT_FIND_POSTIDX.getResponseMessage(),
+                commentService.inputComments(commentRequest, userIdx)), HttpStatus.OK);
+    }
+
+//    @ApiOperation(value = "comment", notes = "[댓글] 회고글에 댓글 목록 조회") // api tag, 설명
+//    @GetMapping("/lists")
+//    public ResponseEntity<Object> getCommentsByPostIdx(@ApiParam(value = "post_idx", required = true, example = "20")
+//                                                           @RequestParam(value = "postIdx") Long postIdx,
+//                                                       @RequestParam(value = "page", defaultValue = "0") Long page,
+//                                                       @RequestParam(value = "pageSize",defaultValue = "20") Integer pageSize) {
+//        if (pageSize == null) pageSize = DEFAULT_SIZE;
+//        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.COMMENT_FIND_POSTIDX.getResponseMessage(),
+//                commentService.getCommmentsListByPostIdx(page, PageRequest.of(0,pageSize))), HttpStatus.OK);
+//    }
+}

--- a/src/main/java/com/yapp18/retrospect/web/dto/ApiDefaultResponse.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/ApiDefaultResponse.java
@@ -3,12 +3,14 @@ package com.yapp18.retrospect.web.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.http.HttpStatus;
 
 @Data
 @AllArgsConstructor
 @Builder
 public class ApiDefaultResponse<T> {
     private int statusCode;
+//    private HttpStatus status;
     private String responseMessage;
     private T data;
 
@@ -18,14 +20,25 @@ public class ApiDefaultResponse<T> {
         this.data = null;
     }
 
-    // state, message만 반환
-    public static<T> ApiDefaultResponse<T> res(final int statusCode, final String responseMessage) {
-        return res(statusCode, responseMessage);
-    }
+//    public static<T> ApiDefaultResponse<T> res(final int statusCode, final String responseMessage) {
+//        return res(statusCode, responseMessage);
+//    }
+
+//    public static<T> ApiDefaultResponse<T> res(final HttpStatus status, final String responseMessage) {
+//        return res(status, responseMessage);
+//    }
 
     public static<T> ApiDefaultResponse<T> res(final int statusCode, final String responseMessage, final T t){
         return ApiDefaultResponse.<T>builder()
                 .data(t)
+                .statusCode(statusCode)
+                .responseMessage(responseMessage)
+                .build();
+    }
+
+    // state, message만 반환
+    public static<T> ApiDefaultResponse<T> res(final int statusCode, final String responseMessage){
+        return ApiDefaultResponse.<T>builder()
                 .statusCode(statusCode)
                 .responseMessage(responseMessage)
                 .build();

--- a/src/main/java/com/yapp18/retrospect/web/dto/CommentDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/CommentDto.java
@@ -13,23 +13,44 @@ import java.time.LocalDateTime;
 
 @Getter
 public class CommentDto {
-
     @Getter
-    public static class CommentRequest {
+    public static class CommentInputRequest {
         @ApiModelProperty(value = "회고글 idx")
         private final Long postIdx;
-        @ApiModelProperty(value = "내용")
+        @ApiModelProperty(value = "댓글 내용")
         private final String comments;
 
         @Builder
-        public CommentRequest(Long postIdx, String comments) {
+        public CommentInputRequest(Long postIdx, String comments) {
             this.postIdx = postIdx;
             this.comments = comments;
         }
 
-        public Comment toEntity(User user, Post post){
+        public Comment toEntity(Post post, User user){
             return Comment.builder()
                     .comments(this.comments)
+                    .post(post)
+                    .user(user)
+                    .build();
+        }
+    }
+
+    @Getter
+    public static class CommentUpdateRequest {
+        @ApiModelProperty(value = "댓글 내용")
+        private final String comments;
+        @ApiModelProperty(value = "회고글 idx")
+        private final Long postIdx;
+
+        @Builder
+        public CommentUpdateRequest(String comments, Long postIdx) {
+            this.comments = comments;
+            this.postIdx = postIdx;
+        }
+
+        public Comment toEntity(User user, Post post){
+            return Comment.builder()
+                    .comments(comments)
                     .user(user)
                     .post(post)
                     .build();
@@ -37,7 +58,7 @@ public class CommentDto {
     }
 
     @Getter
-    public static class ListResponse {
+    public static class CommentResponse {
         @ApiModelProperty(value = "댓글 idx")
         private final Long commentIdx;
 
@@ -47,6 +68,9 @@ public class CommentDto {
         @JsonIgnore
         @ApiModelProperty(value = "작성자")
         private final User user;
+
+        @ApiModelProperty(value = "작성자 idx")
+        private final Long userIdx;
 
         @ApiModelProperty(value = "작성자 닉네임")
         private final String nickname;
@@ -63,10 +87,11 @@ public class CommentDto {
         private final LocalDateTime modifiedAt;
 
         @Builder
-        public ListResponse(Long commentIdx, String comments, User user, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        public CommentResponse(Long commentIdx, String comments, User user, LocalDateTime createdAt, LocalDateTime modifiedAt) {
             this.commentIdx = commentIdx;
             this.comments = comments;
             this.user = user;
+            this.userIdx = user.getUserIdx();
             this.nickname = user.getNickname();
             this.profile = user.getProfile();
             this.createdAt = createdAt;

--- a/src/main/java/com/yapp18/retrospect/web/dto/CommentDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/CommentDto.java
@@ -1,14 +1,15 @@
 package com.yapp18.retrospect.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.yapp18.retrospect.domain.comment.Comment;
 import com.yapp18.retrospect.domain.post.Post;
 import com.yapp18.retrospect.domain.user.User;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 public class CommentDto {
@@ -28,7 +29,7 @@ public class CommentDto {
 
         public Comment toEntity(User user, Post post){
             return Comment.builder()
-                    .comment(this.comments)
+                    .comments(this.comments)
                     .user(user)
                     .post(post)
                     .build();
@@ -43,26 +44,31 @@ public class CommentDto {
         @ApiModelProperty(value = "내용")
         private final String comments;
 
-        @ApiModelProperty(value = "작성자 닉네임 ")
+        @JsonIgnore
+        @ApiModelProperty(value = "작성자")
+        private final User user;
+
+        @ApiModelProperty(value = "작성자 닉네임")
         private final String nickname;
 
         @ApiModelProperty(value = "작성자 프로필 사진")
         private final String profile;
 
-        @JsonFormat(pattern = "MMM dd, yyyy", locale = "en_GB")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", locale = "en_GB")
         @ApiModelProperty(value = "생성날짜")
         private final LocalDateTime createdAt;
 
-        @JsonFormat(pattern = "MMM dd, yyyy", locale = "en_GB")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", locale = "en_GB")
         @ApiModelProperty(value = "수정날짜")
         private final LocalDateTime modifiedAt;
 
         @Builder
-        public ListResponse(Long commentIdx, String comments, String nickname, String profile, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        public ListResponse(Long commentIdx, String comments, User user, LocalDateTime createdAt, LocalDateTime modifiedAt) {
             this.commentIdx = commentIdx;
             this.comments = comments;
-            this.nickname = nickname;
-            this.profile = profile;
+            this.user = user;
+            this.nickname = user.getNickname();
+            this.profile = user.getProfile();
             this.createdAt = createdAt;
             this.modifiedAt = modifiedAt;
         }

--- a/src/main/java/com/yapp18/retrospect/web/dto/CommentDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/CommentDto.java
@@ -1,0 +1,70 @@
+package com.yapp18.retrospect.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.yapp18.retrospect.domain.comment.Comment;
+import com.yapp18.retrospect.domain.post.Post;
+import com.yapp18.retrospect.domain.user.User;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class CommentDto {
+
+    @Getter
+    public static class CommentRequest {
+        @ApiModelProperty(value = "회고글 idx")
+        private final Long postIdx;
+        @ApiModelProperty(value = "내용")
+        private final String comments;
+
+        @Builder
+        public CommentRequest(Long postIdx, String comments) {
+            this.postIdx = postIdx;
+            this.comments = comments;
+        }
+
+        public Comment toEntity(User user, Post post){
+            return Comment.builder()
+                    .comment(this.comments)
+                    .user(user)
+                    .post(post)
+                    .build();
+        }
+    }
+
+    @Getter
+    public static class ListResponse {
+        @ApiModelProperty(value = "댓글 idx")
+        private final Long commentIdx;
+
+        @ApiModelProperty(value = "내용")
+        private final String comments;
+
+        @ApiModelProperty(value = "작성자 닉네임 ")
+        private final String nickname;
+
+        @ApiModelProperty(value = "작성자 프로필 사진")
+        private final String profile;
+
+        @JsonFormat(pattern = "MMM dd, yyyy", locale = "en_GB")
+        @ApiModelProperty(value = "생성날짜")
+        private final LocalDateTime createdAt;
+
+        @JsonFormat(pattern = "MMM dd, yyyy", locale = "en_GB")
+        @ApiModelProperty(value = "수정날짜")
+        private final LocalDateTime modifiedAt;
+
+        @Builder
+        public ListResponse(Long commentIdx, String comments, String nickname, String profile, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+            this.commentIdx = commentIdx;
+            this.comments = comments;
+            this.nickname = nickname;
+            this.profile = profile;
+            this.createdAt = createdAt;
+            this.modifiedAt = modifiedAt;
+        }
+    }
+}


### PR DESCRIPTION
## 1. 댓글 CRUD 추가

아직 토큰 값과 작성자 비교해서 권한 있을때만 UD 가능하게 하는 기능은 없습니다.
기본적인 틀만 구현했기 때문에 추후에 수정이 필요합니다.

CRUD 만들다보니 중복되는 코드가 상당히 많네요
빠른 시일 내에 AOP 적용하는게 좋을 것 같습니다.

## 2. 에러 핸들러 추가

`@RestControllerAdvice`와 `@ExceptionHandler`를 사용해서 
Controller 전체에 적용할 수 있는 간단한 에러 핸들러를 만들었습니다.
관련 파일은 web/advice 폴더에 있으므로 참조해주세요.

조만간 회의를 통해 API, 에러 응답 형식에 대해 통일할 필요가 있는 것 같습니다
