### PR TITLE
[스크랩] 스크랩 추가, 삭제 기능 / SQL 예외 처리 추가 / TokenService 리팩토링, 예외 처리

### DIFF
--- a/src/main/java/com/yapp18/retrospect/config/ResponseMessage.java
+++ b/src/main/java/com/yapp18/retrospect/config/ResponseMessage.java
@@ -38,10 +38,11 @@ public enum ResponseMessage {
     COMMENT_FIND_POSTIDX("회고글에 달린 댓글 리스트 조회 성공"),
     COMMENT_COUNT_POSTIDX("회고글에 달린 댓글 갯수 조회 성공"),
 
+    LIKE_SAVE("스크랩 추가 성공"),
+    LIKE_DELETE("스크랩 한 글 삭제 성공"),
     // 이미지 업로드
     IMAGE_UPLOAD("이미지 업로드 성공 ")
     ;
-
 
     private final String ResponseMessage;
 

--- a/src/main/java/com/yapp18/retrospect/config/TokenErrorInfo.java
+++ b/src/main/java/com/yapp18/retrospect/config/TokenErrorInfo.java
@@ -4,13 +4,20 @@ import lombok.Getter;
 
 @Getter
 public enum TokenErrorInfo {
-    EXPIRED_JWT("TE001", "TokenExpiredError", "만료된 JWT"),
-    INVALID_SIGNATURE("TE002", "SignatureException", "유효하지 않은 JWT 서명"),
-    MALFORMED_JWT( "TE003", "MalformedJwtException", "올바르지 않은 JWT 구성"),
-    UNSUPPORTED_JWT( "TE004", "UnsupportedJwtException", "지원하지 않는 JWT 형식"),
-    ILLEGAL_ARGUMENT( "TE005", "IllegalArgumentException", "비어있는 Authorization 헤더"),
-    ILLEGAL_GRANTTYPE( "TE006", "IllegalArgumentException", "비어있는 GrantType"),
-    ACCESS_DENIED( "TE007", "AccessDenied", "접근이 거부됨");
+    EXPIRED_ACCESS("TE001", "TokenExpiredError", "Access Token이 만료됨"),
+    EXPIRED_REFRESH("TE002", "TokenExpiredError", "Refresh Token이 만료됨"),
+    INVALID_SIGNATURE_ACCESS("TE003", "SignatureException", "Access Token의 서명이 유효하지 않음"),
+    INVALID_SIGNATURE_REFRESH("TE004", "SignatureException", "Refresh Token의 서명이 유효하지 않음"),
+    MALFORMED_ACCESS( "TE005", "MalformedJwtException", "Access Token의 구성이 올바르지 않음"),
+    MALFORMED_REFRESH( "TE006", "MalformedJwtException", "Refresh Token의 구성이 올바르지 않음"),
+    UNSUPPORTED_ACCESS( "TE007", "UnsupportedJwtException", "지원하지 않는 형식의 Access Token"),
+    UNSUPPORTED_REFRESH( "TE008", "UnsupportedJwtException", "지원하지 않는 형식의 Refresh Token"),
+    ILLEGAL_ARGUMENT_ACCESS( "TE009", "IllegalArgumentException", "비어있는 Authorization 헤더"),
+    ILLEGAL_ARGUMENT_REFRESH( "TE010", "IllegalArgumentException", "비어있는 refreshToken 바디"),
+    ILLEGAL_GRANTTYPE( "TE011", "IllegalArgumentException", "비어있는 GrantType"),
+    ACCESS_DENIED( "TE012", "AccessDenied", "접근이 거부됨"),
+    NOT_EXPIRED_ACCESS( "TE013", "TokenNotExpired", "만료되지 않은 Access Token"),
+    UNMATCHED_TOKEN_PAYLOAD( "TE014", "UnmatchedTokenPayload", "Access Token과 Refresh Token의 페이로드 불일치");
 
     private final String code;
     private final String exception;

--- a/src/main/java/com/yapp18/retrospect/domain/like/Like.java
+++ b/src/main/java/com/yapp18/retrospect/domain/like/Like.java
@@ -12,7 +12,14 @@ import javax.persistence.*;
 @NoArgsConstructor
 @Getter
 @Entity
-@Table(name = "like_tb")
+@Table(
+        name="like_tb",
+        uniqueConstraints={
+                @UniqueConstraint(
+                        columnNames={"post_idx","user_idx"}
+                )
+        }
+)
 public class Like extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/yapp18/retrospect/domain/like/LikeRepository.java
+++ b/src/main/java/com/yapp18/retrospect/domain/like/LikeRepository.java
@@ -3,10 +3,15 @@ package com.yapp18.retrospect.domain.like;
 import com.yapp18.retrospect.domain.post.Post;
 import com.yapp18.retrospect.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
-
     Optional<Like> findByPostAndUserUserIdx(Post post, Long UserIdx);
+
+    @Query(value = "SELECT like_idx FROM like_tb WHERE (like_tb.post_idx =: postIdx) AND (like_tb.user_idx =: userIdx)",  nativeQuery = true)
+    Like findByPostIdxAndUserIdx(Long postIdx, Long userIdx);
+
+//    Like findByPostAndUser(Post post, User user);
 }

--- a/src/main/java/com/yapp18/retrospect/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/yapp18/retrospect/security/JwtAuthenticationEntryPoint.java
@@ -23,18 +23,18 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         String errorCode = (String)request.getAttribute("errorCode");
 
         logger.error(errorCode);
-        if(errorCode.equals(TokenErrorInfo.ILLEGAL_ARGUMENT.getCode())){ // 헤더에 토큰이 없는 경우
-            setResponse(response, TokenErrorInfo.ILLEGAL_ARGUMENT);
+        if(errorCode.equals(TokenErrorInfo.ILLEGAL_ARGUMENT_ACCESS.getCode())){ // 헤더에 토큰이 없는 경우
+            setResponse(response, TokenErrorInfo.ILLEGAL_ARGUMENT_ACCESS);
         } else if(errorCode.equals(TokenErrorInfo.ILLEGAL_GRANTTYPE.getCode())){
             setResponse(response, TokenErrorInfo.ILLEGAL_GRANTTYPE);
-        } else if(errorCode.equals(TokenErrorInfo.EXPIRED_JWT.getCode())) {
-            setResponse(response, TokenErrorInfo.EXPIRED_JWT);
-        } else if(errorCode.equals(TokenErrorInfo.INVALID_SIGNATURE.getCode())) {
-            setResponse(response, TokenErrorInfo.INVALID_SIGNATURE);
-        } else if(errorCode.equals(TokenErrorInfo.MALFORMED_JWT.getCode())) {
-            setResponse(response, TokenErrorInfo.MALFORMED_JWT);
-        } else if(errorCode.equals(TokenErrorInfo.UNSUPPORTED_JWT.getCode())) {
-            setResponse(response, TokenErrorInfo.UNSUPPORTED_JWT);
+        } else if(errorCode.equals(TokenErrorInfo.EXPIRED_ACCESS.getCode())) {
+            setResponse(response, TokenErrorInfo.EXPIRED_ACCESS);
+        } else if(errorCode.equals(TokenErrorInfo.INVALID_SIGNATURE_ACCESS.getCode())) {
+            setResponse(response, TokenErrorInfo.INVALID_SIGNATURE_ACCESS);
+        } else if(errorCode.equals(TokenErrorInfo.MALFORMED_ACCESS.getCode())) {
+            setResponse(response, TokenErrorInfo.MALFORMED_ACCESS);
+        } else if(errorCode.equals(TokenErrorInfo.UNSUPPORTED_ACCESS.getCode())) {
+            setResponse(response, TokenErrorInfo.UNSUPPORTED_ACCESS);
         }
     }
 

--- a/src/main/java/com/yapp18/retrospect/security/TokenAuthenticationFilter.java
+++ b/src/main/java/com/yapp18/retrospect/security/TokenAuthenticationFilter.java
@@ -44,14 +44,11 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         try {
             String jwt = tokenService.getTokenFromRequest(request);
             String secret = appProperties.getAuth().getAccessTokenSecret();
-            if (tokenService.validateToken(request, jwt, secret)) {
-                //매 토큰 인증마다 DB를 통해 유저 정보를 불러오는 것은 Stateless 하지 않음
-                //SecurityContextHolder.getContext에 Authentication값을 세팅시 유저의 모든 정보를 세팅할 필요는 없고 권한 정보만 세팅해도 됩니다.
-                UsernamePasswordAuthenticationToken authentication = tokenService.getAuthentication(jwt, secret);
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
+            //매 토큰 인증마다 DB를 통해 유저 정보를 불러오는 것은 Stateless 하지 않음
+            //SecurityContextHolder.getContext에 Authentication값을 세팅시 유저의 모든 정보를 세팅할 필요는 없고 권한 정보만 세팅해도 됩니다.
+            UsernamePasswordAuthenticationToken authentication = tokenService.getAuthentication(jwt, secret);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (Exception exception) {
             logger.error("Security Context에서 사용자 인증을 설정할 수 없습니다", exception);
         }

--- a/src/main/java/com/yapp18/retrospect/security/TokenAuthenticationFilter.java
+++ b/src/main/java/com/yapp18/retrospect/security/TokenAuthenticationFilter.java
@@ -42,7 +42,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         //가입/로그인/재발급을 제외한 모든 Request 요청은 이 필터를 거치기 때문에 토큰 정보가 없거나 유효하지 않으면 정상적으로 수행되지 않습니다.
         //그리고 요청이 정상적으로 Controller 까지 도착했다면 SecurityContext 에 Member ID 가 존재한다는 것이 보장됩니다.
         try {
-            System.out.println(request.getMethod());
             String jwt = tokenService.getTokenFromRequest(request);
             String secret = appProperties.getAuth().getAccessTokenSecret();
             if (tokenService.validateToken(request, jwt, secret)) {

--- a/src/main/java/com/yapp18/retrospect/service/CommentService.java
+++ b/src/main/java/com/yapp18/retrospect/service/CommentService.java
@@ -39,7 +39,7 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public List<CommentDto.BasicResponse> getCommmentsListByPostIdx(Long postIdx, Long userIdx, Pageable page){
-        Post post = postRepository.findByPostIdx(userIdx)
+        Post post = postRepository.findByPostIdx(postIdx)
                 .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL)); // 없으면 post 존재하지 않을때도 그냥 빈 배열 반환
 
         return commentRepository.findAllByPost(post, page)

--- a/src/main/java/com/yapp18/retrospect/service/LikeService.java
+++ b/src/main/java/com/yapp18/retrospect/service/LikeService.java
@@ -1,0 +1,47 @@
+package com.yapp18.retrospect.service;
+
+import com.yapp18.retrospect.config.ErrorInfo;
+import com.yapp18.retrospect.domain.like.Like;
+import com.yapp18.retrospect.domain.like.LikeRepository;
+import com.yapp18.retrospect.domain.post.Post;
+import com.yapp18.retrospect.domain.post.PostRepository;
+import com.yapp18.retrospect.domain.user.User;
+import com.yapp18.retrospect.domain.user.UserRepository;
+import com.yapp18.retrospect.web.advice.EntityNullException;
+import com.yapp18.retrospect.web.dto.LikeDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public boolean isExist(LikeDto.InputRequest inputRequest, Long userIdx){
+        return likeRepository.findByPostIdxAndUserIdx(inputRequest.getPostIdx(), userIdx) != null;
+    }
+
+    @Transactional
+    public Long inputLikes(LikeDto.InputRequest inputRequest, Long userIdx){
+        User user = userRepository.findByUserIdx(userIdx)
+                .orElseThrow(() -> new EntityNullException(ErrorInfo.USER_NULL));
+
+        Post post = postRepository.findByPostIdx(inputRequest.getPostIdx())
+                .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
+
+        return likeRepository.save(inputRequest.toEntity(post, user)).getLikeIdx();
+    }
+
+    @Transactional
+    public void deleteLikes(Long likeIdx){
+        Like like = likeRepository.findById(likeIdx)
+                .orElseThrow(() -> new EntityNullException(ErrorInfo.LIKE_NULL));
+
+        likeRepository.delete(like);
+    }
+}

--- a/src/main/java/com/yapp18/retrospect/web/advice/ControllerAdvice.java
+++ b/src/main/java/com/yapp18/retrospect/web/advice/ControllerAdvice.java
@@ -11,16 +11,12 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
 @RestControllerAdvice
 public class ControllerAdvice {
-//    @ExceptionHandler(EntityNullException.class)
-//    public ResponseEntity<Object> entityNullExceptionHandler(EntityNullException e) {
-//        return new ResponseEntity<>(ApiDefaultResponse.res(404, e.getMessage()), e.getStatus());
-//    }
-
     @ExceptionHandler(EntityNullException.class)
     public ResponseEntity<Object> entityNullExceptionHandler(EntityNullException e) {
         return new ResponseEntity<>(ErrorDefaultResponse.res(
@@ -32,19 +28,21 @@ public class ControllerAdvice {
         ), HttpStatus.NOT_FOUND);
     }
 
-//    @ResponseStatus(HttpStatus.BAD_REQUEST)
-//    @ExceptionHandler(IllegalArgumentException.class)
-//    public void illegalArgumentExceptionHandler(IllegalArgumentException e) {
-//    }
+    @ExceptionHandler(SQLException.class)
+    public ResponseEntity<Object> sqlExceptionHandler(SQLException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorDefaultResponse.res(
+                        ErrorDto.builder()
+                                .code("DE" + e.getSQLState())
+                                .exception(e.toString().split(":")[0])
+                                .message(e.getMessage())
+                                .build()
+                ));
+    }
 
-//    @ResponseStatus(HttpStatus.BAD_REQUEST)
-//    @ExceptionHandler(OAuth2AuthenticationProcessingException.class)
-//    public void oauthAuthenticationProcessingExceptionHandler(OAuth2AuthenticationProcessingException e){
-//    }
-
-//    @ResponseStatus(HttpStatus.BAD_REQUEST)
-//    @ExceptionHandler(RuntimeException.class)
-//    public void runtimeExceptionHandler(RuntimeException e) {
+//    @ExceptionHandler(RuntimeException.class) // RuntimeException으로 뭉뚱그리면 SQLException 까지 포함됨 
+//    public ResponseEntity<Object> runtimeExceptionHandler(RuntimeException e) {
+//        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorDefaultResponse.res(e));
 //    }
 
     @ExceptionHandler(IllegalArgumentException.class)
@@ -59,4 +57,21 @@ public class ControllerAdvice {
 
         return new ResponseEntity<>(resBody, e.getStatus());
     }
+
+//    @ExceptionHandler(EntityNullException.class)
+//    public ResponseEntity<Object> entityNullExceptionHandler(EntityNullException e) {
+//        return new ResponseEntity<>(ApiDefaultResponse.res(404, e.getMessage()), e.getStatus());
+//    }
+
+//    @ResponseStatus(HttpStatus.BAD_REQUEST)
+//    @ExceptionHandler(IllegalArgumentException.class)
+//    public void illegalArgumentExceptionHandler(IllegalArgumentException e) {
+//    }
+
+//    @ResponseStatus(HttpStatus.BAD_REQUEST)
+//    @ExceptionHandler(OAuth2AuthenticationProcessingException.class)
+//    public void oauthAuthenticationProcessingExceptionHandler(OAuth2AuthenticationProcessingException e){
+//    }
+
+
 }

--- a/src/main/java/com/yapp18/retrospect/web/advice/ControllerAdvice.java
+++ b/src/main/java/com/yapp18/retrospect/web/advice/ControllerAdvice.java
@@ -1,14 +1,10 @@
 package com.yapp18.retrospect.web.advice;
 
-import com.yapp18.retrospect.config.ResponseMessage;
-import com.yapp18.retrospect.exception.OAuth2AuthenticationProcessingException;
-import com.yapp18.retrospect.web.dto.ApiDefaultResponse;
 import com.yapp18.retrospect.web.dto.ErrorDefaultResponse;
 import com.yapp18.retrospect.web.dto.ErrorDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.sql.SQLException;
@@ -37,7 +33,8 @@ public class ControllerAdvice {
                                 .exception(e.toString().split(":")[0])
                                 .message(e.getMessage())
                                 .build()
-                ));
+                        )
+                );
     }
 
 //    @ExceptionHandler(RuntimeException.class) // RuntimeException으로 뭉뚱그리면 SQLException 까지 포함됨 
@@ -45,9 +42,17 @@ public class ControllerAdvice {
 //        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorDefaultResponse.res(e));
 //    }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Object> illegalArgumentExceptionHandler(IllegalArgumentException e) {
-        return new ResponseEntity<>(ErrorDefaultResponse.res(e), HttpStatus.BAD_REQUEST);
+    @ExceptionHandler(TokenException.class)
+    public ResponseEntity<Object> tokenAbsenceExceptionHandler(TokenException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorDefaultResponse.res(
+                        ErrorDto.builder()
+                                .code(e.getCode())
+                                .exception(e.getException())
+                                .message(e.getMessage())
+                                .build()
+                        )
+                );
     }
 
     @ExceptionHandler(RestException.class)

--- a/src/main/java/com/yapp18/retrospect/web/advice/TokenException.java
+++ b/src/main/java/com/yapp18/retrospect/web/advice/TokenException.java
@@ -1,0 +1,18 @@
+package com.yapp18.retrospect.web.advice;
+
+import com.yapp18.retrospect.config.ErrorInfo;
+import com.yapp18.retrospect.config.TokenErrorInfo;
+import lombok.Getter;
+
+@Getter
+public class TokenException extends IllegalArgumentException {
+    private String code;
+    private String exception;
+    private String message;
+
+    public TokenException(TokenErrorInfo tokenErrorInfo) {
+        this.code = tokenErrorInfo.getCode();
+        this.exception = tokenErrorInfo.getException();
+        this.message = tokenErrorInfo.getMessage();
+    }
+}

--- a/src/main/java/com/yapp18/retrospect/web/controller/AuthController.java
+++ b/src/main/java/com/yapp18/retrospect/web/controller/AuthController.java
@@ -4,9 +4,11 @@ package com.yapp18.retrospect.web.controller;
 //<a href="/oauth2/authorization/google"> : 스프링 시큐리티에서 제공하는 로그인 url
 
 import com.yapp18.retrospect.config.ResponseMessage;
+import com.yapp18.retrospect.config.TokenErrorInfo;
 import com.yapp18.retrospect.domain.user.UserRepository;
 import com.yapp18.retrospect.security.oauth2.CookieUtils;
 import com.yapp18.retrospect.service.TokenService;
+import com.yapp18.retrospect.web.advice.TokenException;
 import com.yapp18.retrospect.web.dto.ApiDefaultResponse;
 import com.yapp18.retrospect.web.dto.AuthDto;
 import io.swagger.annotations.Api;
@@ -48,13 +50,13 @@ public class AuthController {
 //                HttpStatus.OK);
 //    }
 
-    @ApiOperation(value = "auth", notes = "[인증] Access Token 재발급, 쿠키에 JWT-Refresh-Token 필요")
+    @ApiOperation(value = "auth", notes = "[인증] Access Token 재발급")
     @PostMapping("/reissue")
     public ResponseEntity<Object> reissue (HttpServletRequest request,
                                            @RequestBody AuthDto.ReissueRequest reissueRequest) {
-        return new ResponseEntity<>(ApiDefaultResponse.res(200,
+        return new ResponseEntity<>(ApiDefaultResponse.res(201,
                 ResponseMessage.AUTH_REISSUE.getResponseMessage(),
                 tokenService.reissueAccessToken(request, reissueRequest)),
-                HttpStatus.OK);
+                HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/yapp18/retrospect/web/controller/LikeController.java
+++ b/src/main/java/com/yapp18/retrospect/web/controller/LikeController.java
@@ -1,0 +1,58 @@
+package com.yapp18.retrospect.web.controller;
+
+import com.yapp18.retrospect.config.ResponseMessage;
+import com.yapp18.retrospect.service.LikeService;
+import com.yapp18.retrospect.service.TokenService;
+import com.yapp18.retrospect.web.dto.ApiDefaultResponse;
+import com.yapp18.retrospect.web.dto.LikeDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RequiredArgsConstructor
+@RestController
+@Api(value = "LikeController") // swagger 리소스 명시
+@RequestMapping("/api/v2/likes")
+public class LikeController {
+    private final LikeService likeService;
+    private final TokenService tokenService;
+
+    @ApiOperation(value = "like", notes = "[스크랩] 회고글 스크랩") // api tag, 설명
+    @PostMapping("")
+    public ResponseEntity<Object> inputLikes(HttpServletRequest request,
+                                             @RequestBody LikeDto.InputRequest inputRequest) {
+        Long userIdx = (tokenService.getTokenFromRequest(request) != null) ? tokenService.getUserIdx(tokenService.getTokenFromRequest(request)) : 0L;
+        return new ResponseEntity<>(ApiDefaultResponse.res(201, ResponseMessage.LIKE_SAVE.getResponseMessage(),
+                likeService.inputLikes(inputRequest, userIdx)), HttpStatus.CREATED);
+    }
+
+    @ApiOperation(value = "like", notes = "[스크랩] 스크랩 한 글 삭제") // api tag, 설명
+    @DeleteMapping("/{likeIdx}")
+    public ResponseEntity<Object> deleteLikes(HttpServletRequest request,
+                                              @ApiParam(value = "삭제 like_idx", required = true, example = "3")
+                                              @PathVariable(value = "likeIdx") Long likeIdx){
+        Long userIdx = (tokenService.getTokenFromRequest(request) != null) ? tokenService.getUserIdx(tokenService.getTokenFromRequest(request)) : 0L;
+        likeService.deleteLikes(likeIdx);
+        return new ResponseEntity<>(ApiDefaultResponse.res(204, ResponseMessage.LIKE_SAVE.getResponseMessage()), HttpStatus.NO_CONTENT);
+    }
+
+//    @ApiOperation(value = "like", notes = "[스크랩] 회고글 스크랩") // api tag, 설명
+//    @PostMapping("")
+//    public ResponseEntity<Object> inputLikes(HttpServletRequest request,
+//                                               @RequestBody LikeDto.InputRequest inputRequest){
+//        Long userIdx = (tokenService.getTokenFromRequest(request) != null) ? tokenService.getUserIdx(tokenService.getTokenFromRequest(request)) : 0L;
+//        if(likeService.isExist(inputRequest, userIdx)){ // 중복 검사
+//            return new ResponseEntity<>(ApiDefaultResponse.res(201, ResponseMessage.LIKE_SAVE.getResponseMessage(),
+//                    likeService.inputLikes(inputRequest, userIdx)), HttpStatus.CREATED);
+//        } else {
+//            return new ResponseEntity<>(ApiDefaultResponse.res(500, ResponseMessage.LIKE_SAVE.getResponseMessage(),
+//                    likeService.inputLikes(inputRequest, userIdx)), HttpStatus.);
+//        }
+//    }
+}

--- a/src/main/java/com/yapp18/retrospect/web/dto/LikeDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/LikeDto.java
@@ -1,0 +1,36 @@
+package com.yapp18.retrospect.web.dto;
+
+import com.yapp18.retrospect.domain.like.Like;
+import com.yapp18.retrospect.domain.post.Post;
+import com.yapp18.retrospect.domain.user.User;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+public class LikeDto {
+    @Getter
+    @Setter
+    @ApiModel(value = "회고글 스크랩 등록", description = "회고글 스크랩 등록 요청 모델")
+    public static class InputRequest {
+        @ApiModelProperty(value = "회고글 idx")
+        private Long postIdx;
+
+        public Like toEntity(Post post, User user){
+            return Like.builder()
+                    .post(post)
+                    .user(user)
+                    .build();
+        }
+    }
+
+//    @Getter
+//    @Setter
+//    @ApiModel(value = "회고글 스크랩 등록", description = "스크랩 한 회고글 기본 응답 모델")
+//    public static class BasicResponse {
+//        @ApiModelProperty(value = "회고글 idx")
+//        private String postIdx;
+//    }
+}


### PR DESCRIPTION
## 스크랩 추가 기능

* 유저가 같은 글을 여러번 스크랩 할 수 없도록 {user_idx, post_idx}을 unique 제약조건 설정
* 기능을 구현하며 SQLExcpetion 처리할 수 있도록 예외 추가
* ~~자신의 글도 스크랩할 수 없도록 할 예정~~

## 스크랩 삭제 기능
별로 쓸 게 없네요 조회는 메인처럼 무한 스크롤이 적용되서 구현하는데 시간이 좀 걸릴 것 같습니다.

## TokenService 리팩토링, 예외 처리
oauth 브랜치를 따로 빼서 작업할까하다가 그냥 귀찮아서 like 브랜치에 같이 올립니다. 용서해주세요 ㅎㅎ

아무래도 로그인 및 토큰 인증 관련 쪽이 보안상 가장 중요한 부분이라 손을 좀 빨리 대게 되었네요. 

가능하면 Default Exception으로 처리하려고 했으나 서비스 전체에 널리 쓰이는 클래스라 그냥 커스텀 클래스를 만들어 처리해줬습니다.

- [x]  액세스 리프레시 둘다 빠짐 → IllegalArgumentException
- [x]  액세스 있고 리프레시 빠짐 → IllegalArgumentException
- [x]  액세스 빠지고 리프레시 있음 → IllegalArgumentException
- [x]  정상 토큰, 누락 없음 → 정상 발급
- [x]  액세스토큰 Bearer 빼고 → IllegalArgumentException GrantType 예외
- [x]  만료된 액세스 토큰 → TokenExpiredException
- [x]  만료된 리프레시 토큰 → TokenExpiredException

이정도의 테스트케이스는 전부 통과 했습니다.