### PR TITLE
Add : redis 최근 읽은 글 저장 및 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	implementation 'org.slf4j:slf4j-api'
 	implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.3'
 
+	// redis
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-redis', version: '2.3.12.RELEASE'
 
 	//oauth2, security, jwt
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/yapp18/retrospect/RetrospectApplication.java
+++ b/src/main/java/com/yapp18/retrospect/RetrospectApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing    //JPA Auditing 활성화

--- a/src/main/java/com/yapp18/retrospect/config/JacksonConfiguration.java
+++ b/src/main/java/com/yapp18/retrospect/config/JacksonConfiguration.java
@@ -1,0 +1,49 @@
+package com.yapp18.retrospect.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+@Configuration
+public class JacksonConfiguration {
+
+    private final Locale locale = Locale.UK;
+    private  final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("MMM dd, yyyy").withLocale(locale);
+
+    @Bean
+    @Primary
+    public ObjectMapper serializingObjectMapper(){
+        ObjectMapper objectMapper = new ObjectMapper();
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
+        javaTimeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
+        objectMapper.registerModule(javaTimeModule);
+        return objectMapper;
+
+    }
+
+    public class LocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
+        @Override
+        public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            gen.writeString(value.format(DATE_FORMAT));
+        }
+    }
+
+    public class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+        @Override
+        public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+            return LocalDateTime.parse(jsonParser.getText(), DATE_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/yapp18/retrospect/config/RedisRepositoryConfig.java
+++ b/src/main/java/com/yapp18/retrospect/config/RedisRepositoryConfig.java
@@ -1,25 +1,41 @@
 package com.yapp18.retrospect.config;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.yapp18.retrospect.domain.recent.RecentLog;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.*;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 
 @Configuration
 @EnableRedisRepositories(basePackages = "com.yapp18.retrospect.config")
-public class RedisRepositoryConfig {
+public class RedisRepositoryConfig extends CachingConfigurerSupport {
 
     @Value("${spring.redis.host}")
     private String redisHost;
 
     @Value("${spring.redis.port}")
     private int redisPort;
+
+
+    // jackson LocalDateTime mapper
+    @Bean public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.registerModules(new JavaTimeModule(), new Jdk8Module());
+        return mapper;
+    }
 
 
     // redisConnectionFactory 를 통해 외부 redis 를 연결합니다.
@@ -31,8 +47,10 @@ public class RedisRepositoryConfig {
     //RedisTemplate을 통해 RedisConnection에서 넘겨준 byte 값을 객체 직렬화합니다.
     @Bean
     public RedisTemplate<?,?> redisTemplate(){
-        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        RedisTemplate<String, RecentLog> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
         return redisTemplate;
     }
 

--- a/src/main/java/com/yapp18/retrospect/config/RedisRepositoryConfig.java
+++ b/src/main/java/com/yapp18/retrospect/config/RedisRepositoryConfig.java
@@ -1,0 +1,39 @@
+package com.yapp18.retrospect.config;
+
+
+import com.yapp18.retrospect.domain.recent.RecentLog;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.*;
+
+
+@Configuration
+@EnableRedisRepositories(basePackages = "com.yapp18.retrospect.config")
+public class RedisRepositoryConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+
+    // redisConnectionFactory 를 통해 외부 redis 를 연결합니다.
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    //RedisTemplate을 통해 RedisConnection에서 넘겨준 byte 값을 객체 직렬화합니다.
+    @Bean
+    public RedisTemplate<?,?> redisTemplate(){
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/yapp18/retrospect/domain/recent/RecentLog.java
+++ b/src/main/java/com/yapp18/retrospect/domain/recent/RecentLog.java
@@ -8,16 +8,11 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @RedisHash("userIdx")
-@Getter
+@Getter @ToString @NoArgsConstructor @AllArgsConstructor @Builder
 public class RecentLog {
 
     @Id
-    private final Long userIdx;
-    private final PostDto.ListResponse postDto;
+    private  Long userIdx;
+    private  PostDto.ListResponse postDto;
 
-    @Builder
-    public RecentLog(Long userIdx, PostDto.ListResponse postDto){
-        this.userIdx = userIdx;
-        this.postDto = postDto;
-    }
 }

--- a/src/main/java/com/yapp18/retrospect/domain/recent/RecentLog.java
+++ b/src/main/java/com/yapp18/retrospect/domain/recent/RecentLog.java
@@ -1,0 +1,23 @@
+package com.yapp18.retrospect.domain.recent;
+
+
+import com.yapp18.retrospect.domain.post.Post;
+import com.yapp18.retrospect.web.dto.PostDto;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash("userIdx")
+@Getter
+public class RecentLog {
+
+    @Id
+    private final Long userIdx;
+    private final PostDto.ListResponse postDto;
+
+    @Builder
+    public RecentLog(Long userIdx, PostDto.ListResponse postDto){
+        this.userIdx = userIdx;
+        this.postDto = postDto;
+    }
+}

--- a/src/main/java/com/yapp18/retrospect/domain/recent/RecentRepository.java
+++ b/src/main/java/com/yapp18/retrospect/domain/recent/RecentRepository.java
@@ -1,0 +1,7 @@
+package com.yapp18.retrospect.domain.recent;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+public interface RecentRepository extends CrudRepository<RecentLog, Long> {
+}

--- a/src/main/java/com/yapp18/retrospect/service/ListService.java
+++ b/src/main/java/com/yapp18/retrospect/service/ListService.java
@@ -1,13 +1,22 @@
 package com.yapp18.retrospect.service;
 
+import com.yapp18.retrospect.config.ErrorInfo;
+import com.yapp18.retrospect.domain.post.Post;
 import com.yapp18.retrospect.domain.post.PostRepository;
+import com.yapp18.retrospect.domain.recent.RecentLog;
+import com.yapp18.retrospect.domain.recent.RecentRepository;
 import com.yapp18.retrospect.mapper.PostMapper;
+import com.yapp18.retrospect.web.advice.EntityNullException;
 import com.yapp18.retrospect.web.dto.PostDto;
+import com.yapp18.retrospect.web.dto.RedisRequestDto;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.Resource;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,6 +26,9 @@ public class ListService {
 
     private final PostMapper postMapper;
     private final PostRepository postRepository;
+    private final RecentRepository recentRepository;
+
+    private final RedisTemplate<Long, Object> redisTemplate;
 
     @Transactional
     public List<PostDto.ListResponse> findAllPostsByUserIdx(Long userIdx){
@@ -24,4 +36,23 @@ public class ListService {
                 .stream().map(post->postMapper.postToListResponse(post, userIdx))
                 .collect(Collectors.toList());
     }
+
+    // 최근 읽은 글 저장
+    @Transactional
+    public void saveRecentReadPosts(Long userIdx, Long postIdx){
+        Post post = postRepository.findById(postIdx)
+                .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
+        PostDto.ListResponse postDto = postMapper.postToListResponse(post, userIdx);
+        RecentLog result = RecentLog.builder().userIdx(userIdx).postDto(postDto).build();
+        System.out.println("--->>>"+ result.getPostDto());
+        Long id = recentRepository.save(result).getUserIdx();
+        System.out.println("--->>>>"+ id);
+    }
+
+    // 최근 읽은 글 조회
+    @Transactional
+    public RecentLog findRecentPosts(Long userIdx){
+        return recentRepository.findById(userIdx).orElseThrow(() -> new IllegalArgumentException(".///////"));
+    }
+
 }

--- a/src/main/java/com/yapp18/retrospect/service/PostService.java
+++ b/src/main/java/com/yapp18/retrospect/service/PostService.java
@@ -40,6 +40,7 @@ public class PostService {
     private final LikeRepository likeRepository;
     private final PostMapper postMapper;
     private final ImageService imageService;
+    private final ListService listService;
 
     // post idx 조회 나중에 method로 뺄 것
 
@@ -77,6 +78,9 @@ public class PostService {
         Post post = postRepository.findById(postIdx)
                 .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
         post.updateview(post.getView()); // 조회수 증가
+        if(userIdx != 0L){
+            listService.saveRecentReadPosts(userIdx, postIdx); // 최근 읽은 글에 추가
+        }
         return new ApiIsResultResponse<>(isWriter(post.getUser().getUserIdx(),userIdx),
                 isScrap(post, userIdx),
                 postMapper.postToDetailResponse(post)); // 작성자 판단

--- a/src/main/java/com/yapp18/retrospect/service/PostService.java
+++ b/src/main/java/com/yapp18/retrospect/service/PostService.java
@@ -166,20 +166,6 @@ public class PostService {
         return postRepository.existsByPostIdxLessThan(cursorId);
     }
 
-    // 최신순 페이징
-//    private List<Post> getPostsRecent(Long cursorId, Pageable page) {
-//        return cursorId == null || cursorId == 0 ?
-//                postRepository.findAllByOrderByPostIdxDesc(page) : // 가장 최초 포스트
-//                postRepository.findRecent(cursorId, page, postRepository.findCreatedAtByPostIdx(cursorId).getCreatedAt());
-//    }
-
-//    // 카테고리 페이징
-//    private List<Post> getPostCategory(Long cursorId, Pageable page, String query) {
-//        List<String> queryList = Arrays.asList(query.split(","));
-//        return cursorId == null || cursorId == 0 ?
-//                postRepository.findAllByCategoryInOrderByPostIdxDesc(page, queryList) : // 가장 최초 포스트
-//                postRepository.findCategory(cursorId, page, queryList,postRepository.findCreatedAtByPostIdx(cursorId).getCreatedAt());
-//    }
 
     // 누적순 페이징
     private List<Post> getPostsView(Long cursorId, Pageable page){

--- a/src/main/java/com/yapp18/retrospect/web/controller/ListController.java
+++ b/src/main/java/com/yapp18/retrospect/web/controller/ListController.java
@@ -38,4 +38,13 @@ public class ListController {
         return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.MY_LIST.getResponseMessage(), myPostsList), HttpStatus.OK);
     }
 
+    @ApiOperation(value = "mypage", notes = "[마이페이지] 최근 읽은 글 조회 ")
+    @GetMapping("/recent")
+    public ResponseEntity<Object> findRecentPosts(HttpServletRequest request){
+        Long userIdx = tokenService.getUserIdx(tokenService.getTokenFromRequest(request));
+        return new ResponseEntity<>(ApiDefaultResponse.res(200, "",
+                listService.findRecentPosts(userIdx)), HttpStatus.OK);
+    }
+
+
 }

--- a/src/main/java/com/yapp18/retrospect/web/dto/ImageDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/ImageDto.java
@@ -3,12 +3,12 @@ package com.yapp18.retrospect.web.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Getter
 @Setter
 public class ImageDto {
 
     private String imageUrl;
-
-
 
 }

--- a/src/main/java/com/yapp18/retrospect/web/dto/PostDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/PostDto.java
@@ -8,6 +8,7 @@ import com.yapp18.retrospect.domain.user.User;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
+import lombok.experimental.WithBy;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -57,6 +58,7 @@ public class PostDto {
 
         @ApiModelProperty(value = "스크랩 여부")
         private boolean scrap;
+
 
     }
 

--- a/src/main/java/com/yapp18/retrospect/web/dto/PostDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/PostDto.java
@@ -1,6 +1,12 @@
 package com.yapp18.retrospect.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.yapp18.retrospect.domain.image.Image;
 import com.yapp18.retrospect.domain.post.Post;
 import com.yapp18.retrospect.domain.template.Template;
@@ -10,17 +16,20 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 import lombok.experimental.WithBy;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @Builder
 //@AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostDto {
+public class PostDto{
+
+
     @Getter
     @Setter
     @NoArgsConstructor
-    public static class ListResponse {
+    public static class ListResponse implements Serializable{
 
         @ApiModelProperty(value = "회고글 idx")
         private Long postIdx;

--- a/src/main/java/com/yapp18/retrospect/web/dto/RedisRequestDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/RedisRequestDto.java
@@ -1,0 +1,31 @@
+package com.yapp18.retrospect.web.dto;
+
+
+import com.yapp18.retrospect.domain.post.Post;
+import com.yapp18.retrospect.domain.recent.RecentLog;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RedisRequestDto {
+
+    private Long userIdx;
+    private Post post;
+
+//    @Builder
+//    public RedisRequestDto(Long userIdx, Post post){
+//        this.userIdx = userIdx;
+//        this.post = post;
+//    }
+//
+//    public RecentLog toRedisHash(){
+//        return RecentLog.builder()
+//                .userIdx(userIdx)
+//                .post(post)
+//                .build();
+//    }
+
+
+}

--- a/src/main/java/com/yapp18/retrospect/web/dto/TagDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/TagDto.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Getter
 @Setter
 public class TagDto {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,9 +19,7 @@ spring:
     multipart:
       max-request-size: 10MB
       max-file-size: 10MB
-#  jackson:
-#    serialization:
-#      WRITE_DATES_AS_TIMESTAMPS: false
+
 cloud:
   aws:
     s3:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,9 @@ spring:
     multipart:
       max-request-size: 10MB
       max-file-size: 10MB
+#  jackson:
+#    serialization:
+#      WRITE_DATES_AS_TIMESTAMPS: false
 cloud:
   aws:
     s3:

--- a/src/test/java/com/yapp18/retrospect/RetrospectApplicationTests.java
+++ b/src/test/java/com/yapp18/retrospect/RetrospectApplicationTests.java
@@ -1,8 +1,12 @@
 package com.yapp18.retrospect;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 class RetrospectApplicationTests {
 

--- a/src/test/java/com/yapp18/retrospect/post/PostDomain.java
+++ b/src/test/java/com/yapp18/retrospect/post/PostDomain.java
@@ -1,6 +1,0 @@
-package com.yapp18.retrospect.post;
-
-
-public class PostDomain {
-
-}

--- a/src/test/java/com/yapp18/retrospect/post/PostRecentLogTest.java
+++ b/src/test/java/com/yapp18/retrospect/post/PostRecentLogTest.java
@@ -1,0 +1,59 @@
+//package com.yapp18.retrospect.post;
+//
+//
+//import com.yapp18.retrospect.config.ErrorInfo;
+//import com.yapp18.retrospect.config.SecurityConfig;
+//import com.yapp18.retrospect.domain.post.Post;
+//import com.yapp18.retrospect.domain.post.PostRepository;
+//import com.yapp18.retrospect.domain.recent.RecentLog;
+//import com.yapp18.retrospect.domain.recent.RecentRepository;
+//import com.yapp18.retrospect.security.TokenAuthenticationFilter;
+//import com.yapp18.retrospect.web.advice.EntityNullException;
+//import com.yapp18.retrospect.web.controller.AuthController;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.context.annotation.ComponentScan;
+//import org.springframework.context.annotation.FilterType;
+//import org.springframework.security.test.context.support.WithMockUser;
+//import org.springframework.test.context.junit.jupiter.SpringExtension;
+//import org.springframework.test.web.servlet.MockMvc;
+//
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//
+//@ExtendWith(SpringExtension.class)
+//@WebMvcTest(controllers = AuthController.class,excludeFilters = { @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+//        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = TokenAuthenticationFilter.class) })
+//public class PostRecentLogTest {
+//
+//    @Autowired private MockMvc mvc;
+//
+//    @Autowired
+//    private RecentRepository recentRepository;
+//
+//    @Autowired
+//    private PostRepository postRepository;
+//
+//    @WithMockUser(roles="MEMBER")
+//    @Test
+//    public void Redis_테스트(){
+//        // postIdx 로 해당 post 찾기
+//        Long userIdx = 2L;
+//        Post post = postRepository.findById(73L)
+//                .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
+//        RecentLog result = RecentLog.builder().userIdx(userIdx).post(post).build();
+//        recentRepository.save(result);
+//
+//        RecentLog findMyRecentPosts = recentRepository.findById(userIdx).get();
+//        assertThat(findMyRecentPosts.getPost()).isEqualTo(post);
+//        assertThat(findMyRecentPosts.getUserIdx()).isEqualTo(userIdx);
+//
+//    }
+//
+//
+//
+//}
+//

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -19,3 +19,27 @@ spring:
         format_sql: true # sql prettier
     show-sql: true
     open-in-view: false # 안쓰면 warning 뜸
+  redis:
+    host: localhost
+    port: 6379
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            authorization-grant-type: authorization_code
+            client-id: test
+            client-secret: test
+            scope:
+              - profile
+              - account_email
+            client-authentication-method: POST
+            client-name: Kakao
+          google:
+            client-id: test
+            client-secret: test
+            # 여기서 profile, email을 scope로 강제로 등록한 이유는 openid라는 scope가 있으면 Open Id Provider로 인식하기 때문이다.
+            # 이렇게 되면 OpenId Provider인 서비스(구글)와 그렇지 않은 서비스(카카오 등)로 나눠서 각각 OAuth2Service를 만들어야 한다.
+            scope:
+              - profile
+              - email


### PR DESCRIPTION
### 설명

1. RedisRepositoryConfig  에서 Lettuce로 커넥션 설정
2. 상세조회 시 로그인헀다면 최근 읽은 글 저장하는 서비스 추가
 - RecentLog class에서 처음에는 Post 엔티티를 바로 저장하는 것으로 시도했는데, redis 에서 StackoverFlowError가 났습니다. 해당 글을 보고 해결했는데, Post 등의 엔티티를 직접 저장하는 것이 아니라 dto 등으로 저장해야 하는 것이었습니다. [해결](https://stackoverflow.com/questions/57728041/spring-redis-return-500-stackoverflow-error)
 
3. lists/recent 로 최근 읽은 글 조회하는 API 추가


### 추가해야할 것

- [x] Redis expire date 일주일로 설정해서 저장
- [x] list로 저장되어있는지 성능 체크
- [ ] docker redis와 통신테스트
 