### PR TITLE
Feature : 리소스 수정 및 삭제시 권한 확인 기능 추가, 사용자 삭제(탈퇴) API 추가, 닉네임 중복 조회 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,10 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
-	implementation 'org.slf4j:slf4j-api'
 	implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.3'
 
 
@@ -67,6 +67,10 @@ dependencies {
 	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 	implementation 'io.swagger:swagger-annotations:1.5.21'
 	implementation 'io.swagger:swagger-models:1.5.21'
+
+	//logging
+	implementation 'org.apache.logging.log4j:log4j-core'
+	implementation 'org.slf4j:slf4j-api'
 
 	// test
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/yapp18/retrospect/RetrospectApplication.java
+++ b/src/main/java/com/yapp18/retrospect/RetrospectApplication.java
@@ -6,10 +6,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 
 @EnableJpaAuditing    //JPA Auditing 활성화
 // 프로젝트에 AppProperties를 사용할 수 있도록 선언
 @EnableConfigurationProperties(AppProperties.class)
+@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
 @SpringBootApplication
 public class RetrospectApplication {
 	public static void main(String[] args) {

--- a/src/main/java/com/yapp18/retrospect/aop/AuthAspect.java
+++ b/src/main/java/com/yapp18/retrospect/aop/AuthAspect.java
@@ -1,0 +1,43 @@
+package com.yapp18.retrospect.aop;
+
+import com.yapp18.retrospect.config.ErrorInfo;
+import com.yapp18.retrospect.domain.user.User;
+import com.yapp18.retrospect.domain.user.UserRepository;
+import com.yapp18.retrospect.service.TokenService;
+import com.yapp18.retrospect.service.UserService;
+import com.yapp18.retrospect.web.advice.EntityNullException;
+import com.yapp18.retrospect.web.dto.CommentDto;
+import groovy.util.logging.Slf4j;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AuthAspect {
+    private final UserRepository userRepository;
+    private final TokenService tokenService;
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Around("@annotation(com.yapp18.retrospect.aop.ExtractUser) && args(updateRequest, commentIdx)") // 메소드에 있는 인수 사용가능
+    public Object extractUser(ProceedingJoinPoint pjp, CommentDto.UpdateRequest updateRequest, Long commentIdx) throws Throwable{
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        Long userIdx = tokenService.getUserIdx(tokenService.getTokenFromRequest(request));
+        User user = userRepository.findById(userIdx)
+                .orElseThrow(() -> new EntityNullException(ErrorInfo.USER_NULL));
+        return pjp.proceed(new Object[] { user, updateRequest, commentIdx });
+    }
+}

--- a/src/main/java/com/yapp18/retrospect/aop/ExtractUser.java
+++ b/src/main/java/com/yapp18/retrospect/aop/ExtractUser.java
@@ -1,0 +1,4 @@
+package com.yapp18.retrospect.aop;
+
+public @interface ExtractUser {
+}

--- a/src/main/java/com/yapp18/retrospect/aop/LoggerAspect.java
+++ b/src/main/java/com/yapp18/retrospect/aop/LoggerAspect.java
@@ -1,0 +1,34 @@
+package com.yapp18.retrospect.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+public class LoggerAspect {
+//
+//    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+//
+//    @Pointcut("execution(* com.yapp18.retrospect.web.controller.*Controller.*(..)) || execution(* com.yapp18.retrospect.service.*Service.*(..))")
+//    public void allPointcut() {
+//    }
+//
+//    @Around("allPointcut()")
+//    public Object printLog(ProceedingJoinPoint joinPoint) throws Throwable {
+//
+//        String type = "";
+//        String name = joinPoint.getSignature().getDeclaringTypeName();
+//        if (name.contains("Controller")) {
+//            type = "Controller ===> ";
+//        } else if (name.contains("Service")) {
+//            type = "Service ===> ";
+//        }
+//        logger.info(type + name + "." + joinPoint.getSignature().getName() + "()");
+//        return joinPoint.proceed();
+//    }
+}

--- a/src/main/java/com/yapp18/retrospect/config/ResponseMessage.java
+++ b/src/main/java/com/yapp18/retrospect/config/ResponseMessage.java
@@ -23,8 +23,10 @@ public enum ResponseMessage {
     POST_FIND_CATEGORY("카테고리 필터링 조회 성공"),
     POST_DETAIL("회고글 상세 조회 성공"),
 
-    PROFILE_FIND("프로필 조회 성공"),
-    PROFILE_UPDATE("프로필 업데이트 성공"),
+    USER_FIND("사용자 정보 조회 성공"),
+    USER_UPDATE("사용자 정보 수정 성공"),
+    USER_DELETE("사용자 삭제 성공"),
+
     MY_LIST("내가 쓴 글 조회 성공"),
     AUTH_ISSUE("Access Token 발급 성공"),
     AUTH_REISSUE("Access Token 재발급 성공"),

--- a/src/main/java/com/yapp18/retrospect/domain/comment/Comment.java
+++ b/src/main/java/com/yapp18/retrospect/domain/comment/Comment.java
@@ -6,6 +6,8 @@ import com.yapp18.retrospect.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.persistence.*;
 
@@ -42,15 +44,6 @@ public class Comment extends BaseTimeEntity {
         this.comments = comments;
         this.post = post;
         this.user = user;
-
-        return this;
-    }
-
-    public Comment update(Comment com) {
-        this.commentIdx = com.getCommentIdx();
-        this.comments = com.getComments();
-        this.post = com.getPost();
-        this.user = com.getUser();
 
         return this;
     }

--- a/src/main/java/com/yapp18/retrospect/domain/user/UserRepository.java
+++ b/src/main/java/com/yapp18/retrospect/domain/user/UserRepository.java
@@ -8,5 +8,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     //소셜 로그인으로 반환되는 값 중 email을 통해 이미 생성된 사용자인지 처음 가입하는 사용자인지 판단하기 위한 메소드입니다.
     Optional<User> findByEmail(String email);
     Optional<User> findByUserIdx(Long userIdx);
-    User findByNickname(String nickname);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/yapp18/retrospect/service/UserService.java
+++ b/src/main/java/com/yapp18/retrospect/service/UserService.java
@@ -12,8 +12,7 @@ import com.yapp18.retrospect.web.advice.EntityNullException;
 import com.yapp18.retrospect.web.dto.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -43,6 +42,7 @@ public class UserService {
     }
 
     // userId로 회원 프로필 정보 조회
+    @Transactional
     public UserDto.ProfileResponse getUserProfiles(Long userIdx) {
         return userRepository.findByUserIdx(userIdx)
                 .map(mapper::userToProfileResponse)
@@ -50,6 +50,7 @@ public class UserService {
     }
 
     // 회원 프로필 정보 업데이트
+    @Transactional
     public UserDto.ProfileResponse updateUserProfiles(Long userIdx, UserDto.UpdateRequest request){
         User user = userRepository.findByUserIdx(userIdx)
                 .map(existingUser -> existingUser.updateProfile(request.getProfile(), request.getName(), request.getNickname(), request.getJob(), request.getIntro()))
@@ -58,8 +59,14 @@ public class UserService {
         return mapper.userToProfileResponse(user);
     }
 
+    @Transactional
+    public void deleteUser(Long userIdx){
+        User user = userRepository.findById(userIdx)
+                .orElseThrow(() -> new EntityNullException(ErrorInfo.USER_NULL));
+        userRepository.delete(user);
+    }
+
     public boolean findUserByNickname(String nickname){
-        User user = userRepository.findByNickname(nickname);
-        return user != null;
+        return userRepository.existsByNickname(nickname);
     }
 }

--- a/src/main/java/com/yapp18/retrospect/web/advice/ControllerAdvice.java
+++ b/src/main/java/com/yapp18/retrospect/web/advice/ControllerAdvice.java
@@ -4,6 +4,7 @@ import com.yapp18.retrospect.web.dto.ErrorDefaultResponse;
 import com.yapp18.retrospect.web.dto.ErrorDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -30,6 +31,20 @@ public class ControllerAdvice {
                 .body(ErrorDefaultResponse.res(
                         ErrorDto.builder()
                                 .code("DE" + e.getSQLState())
+                                .exception(e.toString().split(":")[0])
+                                .message(e.getMessage())
+                                .build()
+                        )
+                );
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Object> accessDeniedExceptionHandler(AccessDeniedException e){
+        System.out.println(e);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ErrorDefaultResponse.res(
+                        ErrorDto.builder()
+                                .code("AE001")
                                 .exception(e.toString().split(":")[0])
                                 .message(e.getMessage())
                                 .build()

--- a/src/main/java/com/yapp18/retrospect/web/advice/ControllerAdvice.java
+++ b/src/main/java/com/yapp18/retrospect/web/advice/ControllerAdvice.java
@@ -40,7 +40,6 @@ public class ControllerAdvice {
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<Object> accessDeniedExceptionHandler(AccessDeniedException e){
-        System.out.println(e);
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(ErrorDefaultResponse.res(
                         ErrorDto.builder()

--- a/src/main/java/com/yapp18/retrospect/web/controller/UserController.java
+++ b/src/main/java/com/yapp18/retrospect/web/controller/UserController.java
@@ -1,8 +1,6 @@
 package com.yapp18.retrospect.web.controller;
 
 import com.yapp18.retrospect.config.ResponseMessage;
-import com.yapp18.retrospect.domain.user.User;
-import com.yapp18.retrospect.mapper.UserMapper;
 import com.yapp18.retrospect.service.TokenService;
 import com.yapp18.retrospect.service.UserService;
 import com.yapp18.retrospect.web.dto.ApiDefaultResponse;
@@ -17,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 
 @RestController
 @Api(value = "UserController") // swagger 리소스 명시
@@ -31,25 +28,34 @@ public class UserController {
     @GetMapping("")
     public ResponseEntity<Object> findNickname(@ApiParam (value = "닉네임", required = true, example = "dok2")
                                                @RequestParam(value = "nickname") String nickname) throws UnsupportedEncodingException {
-//        nickname = URLDecoder.decode(nickname, "UTF-8");
-        boolean existNickname = userService.findUserByNickname(nickname);
-        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.NICKNAME_FIND.getResponseMessage(), existNickname), HttpStatus.OK);
+        return new ResponseEntity<>(ApiDefaultResponse.res(200,
+                ResponseMessage.NICKNAME_FIND.getResponseMessage(),
+                userService.findUserByNickname(nickname)), HttpStatus.OK);
     }
 
-    @ApiOperation(value = "profile", notes = "[프로필] 사용자 프로필 조회") // api tag, 설명
+    @ApiOperation(value = "profile", notes = "[프로필] 사용자 정보 조회") // api tag, 설명
     @GetMapping("/profiles/{userIdx}")
     public ResponseEntity<Object> getProfiles(@ApiParam (value = "사용자 user_idx", required = true, example = "1557")
                                                   @PathVariable(value = "userIdx") Long userIdx){
         UserDto.ProfileResponse response = userService.getUserProfiles(userIdx);
-        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.PROFILE_FIND.getResponseMessage(), response), HttpStatus.OK);
+        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.USER_FIND.getResponseMessage(), response), HttpStatus.OK);
     }
 
-    @ApiOperation(value = "profile", notes = "[프로필] 사용자 프로필 업데이트") // api tag, 설명
+    @ApiOperation(value = "profile", notes = "[프로필] 사용자 정보 수정") // api tag, 설명
     @PatchMapping("/profiles")
     public ResponseEntity<Object> updateProfiles(HttpServletRequest request, @RequestBody UserDto.UpdateRequest updateRequest){
-        String token = tokenService.getTokenFromRequest(request);
-        Long userIdx = tokenService.getUserIdx(token);
-        UserDto.ProfileResponse updated = userService.updateUserProfiles(userIdx, updateRequest);
-        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.PROFILE_UPDATE.getResponseMessage(), updated), HttpStatus.OK);
+        Long userIdx = tokenService.getUserIdx(tokenService.getTokenFromRequest(request));
+        return new ResponseEntity<>(ApiDefaultResponse.res(201,
+                        ResponseMessage.USER_UPDATE.getResponseMessage(),
+                        userService.updateUserProfiles(userIdx, updateRequest)),
+                HttpStatus.CREATED);
+    }
+
+    @ApiOperation(value = "user", notes = "[사용자] 사용자 삭제(탈퇴)") // api tag, 설명
+    @DeleteMapping("/profiles")
+    public ResponseEntity<Object> deleteProfiles(HttpServletRequest request){
+        Long userIdx = tokenService.getUserIdx(tokenService.getTokenFromRequest(request));
+        userService.deleteUser(userIdx);
+        return new ResponseEntity<>(ApiDefaultResponse.res(204, ResponseMessage.USER_DELETE.getResponseMessage()), HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/yapp18/retrospect/web/dto/AuthDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/AuthDto.java
@@ -1,5 +1,6 @@
 package com.yapp18.retrospect.web.dto;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +14,7 @@ public class AuthDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @ApiModel(value = "토큰 발급", description = "토큰 발급 응답 모델")
     public static class IssueResponse {
         @ApiModelProperty(value = "권한 타입 (Bearer)")
         private String grantType;
@@ -22,6 +24,7 @@ public class AuthDto {
 
     @Getter
     @NoArgsConstructor
+    @ApiModel(value = "토큰 재발급", description = "토큰 재발급 요청 모델")
     public static class ReissueRequest {
         @ApiModelProperty(value = "유효한 Refresh Token")
         private String refreshToken;
@@ -31,6 +34,7 @@ public class AuthDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @ApiModel(value = "토큰 재발급", description = "토큰 재발급 응답 모델")
     public static class ReissueResponse {
         @ApiModelProperty(value = "권한 타입 (Bearer)")
         private String grantType;

--- a/src/main/java/com/yapp18/retrospect/web/dto/CommentDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/CommentDto.java
@@ -5,15 +5,19 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.yapp18.retrospect.domain.comment.Comment;
 import com.yapp18.retrospect.domain.post.Post;
 import com.yapp18.retrospect.domain.user.User;
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
 public class CommentDto {
     @Getter
+    @ApiModel(value = "댓글 등록", description = "댓글 등록 요청 모델")
     public static class InputRequest {
         @ApiModelProperty(value = "회고글 idx")
         private final Long postIdx;
@@ -36,16 +40,15 @@ public class CommentDto {
     }
 
     @Getter
+    @NoArgsConstructor
+    @ApiModel(value = "댓글 수정", description = "댓글 수정 요청 모델")
     public static class UpdateRequest {
         @ApiModelProperty(value = "댓글 내용")
-        private final String comments;
-        @ApiModelProperty(value = "회고글 idx")
-        private final Long postIdx;
+        private String comments;
 
         @Builder
-        public UpdateRequest(String comments, Long postIdx) {
+        public UpdateRequest(String comments) {
             this.comments = comments;
-            this.postIdx = postIdx;
         }
 
         public Comment toEntity(User user, Post post){
@@ -58,6 +61,7 @@ public class CommentDto {
     }
 
     @Getter
+    @ApiModel(value = "댓글 리스트 조회", description = "댓글 리스트 응답 모델")
     public static class ListResponse<T> {
         @ApiModelProperty(value = "작성자 여부")
         private final boolean isWriter;
@@ -72,6 +76,7 @@ public class CommentDto {
     }
 
     @Getter
+    @ApiModel(value = "댓글 조회", description = "댓글 응답 모델")
     public static class BasicResponse {
         @ApiModelProperty(value = "댓글 idx")
         private final Long commentIdx;

--- a/src/main/java/com/yapp18/retrospect/web/dto/ErrorDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/ErrorDto.java
@@ -1,6 +1,7 @@
 package com.yapp18.retrospect.web.dto;
 
 import com.yapp18.retrospect.web.advice.EntityNullException;
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/yapp18/retrospect/web/dto/LikeDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/LikeDto.java
@@ -32,6 +32,7 @@ public class LikeDto {
     @Getter
     @Setter
     @NoArgsConstructor
+    @ApiModel(value = "회고글 스크랩 조회", description = "회고글 스크랩 응답 모델")
     public static class BasicResponse {
         @ApiModelProperty(value = "스크랩 idx")
         private Long likeIdx;

--- a/src/main/java/com/yapp18/retrospect/web/dto/UserDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/UserDto.java
@@ -1,6 +1,7 @@
 package com.yapp18.retrospect.web.dto;
 
 import com.yapp18.retrospect.domain.user.Role;
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
@@ -32,6 +33,7 @@ public class UserDto implements Serializable {
 //    private String intro;
 
     @Getter
+    @ApiModel(value = "사용자 프로필 조회", description = "사용자 프로필 응답 모델")
     public static class ProfileResponse {
         @ApiModelProperty(value = "회원 이름")
         private String name;
@@ -55,6 +57,7 @@ public class UserDto implements Serializable {
     }
 
     @Getter
+    @ApiModel(value = "사용자 프로필 수정", description = "사용자 프로필 수정 요청 모델")
     public static class UpdateRequest {
         @ApiModelProperty(value = "회원 이름")
         private String name;


### PR DESCRIPTION
1. 타인이 리소스에 접근할 가능성이 있는 메소드에 스프링 시큐리티에서 제공하는 @PreAuthorize로 인수를 비교하여 권한이 없을 시 403 AccessDenied 예외로 처리
2. DELETE `/api/v1/users/profiles` 사용자 삭제(탈퇴) API 추가
3. 닉네임 중복 조회 JPA `existsByNickname`으로 수정