### PR TITLE
Chore: 최근 읽은 글 중복 제거 및 내가 쓴 글 paging처리

### DIFF
--- a/src/main/java/com/yapp18/retrospect/config/ResponseMessage.java
+++ b/src/main/java/com/yapp18/retrospect/config/ResponseMessage.java
@@ -29,6 +29,7 @@ public enum ResponseMessage {
     USER_DELETE("사용자 삭제 성공"),
 
     MY_LIST("내가 쓴 글 조회 성공"),
+    MY_RECENT_LIST("최근 읽은 글 조회 성공"),
     AUTH_ISSUE("Access Token 발급 성공"),
     AUTH_REISSUE("Access Token 재발급 성공"),
     TEMPLATE_FIND("템플릿 조회 성공 "),

--- a/src/main/java/com/yapp18/retrospect/domain/post/PostRepository.java
+++ b/src/main/java/com/yapp18/retrospect/domain/post/PostRepository.java
@@ -13,7 +13,7 @@ public interface  PostRepository extends JpaRepository<Post, Long> {
 
     boolean existsByPostIdxLessThan(Long cursorId);
 
-    List<Post> findAllByUserUserIdxOrderByCreatedAtDesc(Long userIdx);
+    List<Post> findAllByUserUserIdxOrderByCreatedAtDesc(Long userIdx, Pageable pageable);
 
     // 쓴 날짜 찾기
     Post findCreatedAtByPostIdx(Long postIdx);

--- a/src/main/java/com/yapp18/retrospect/domain/recent/RecentLog.java
+++ b/src/main/java/com/yapp18/retrospect/domain/recent/RecentLog.java
@@ -7,12 +7,15 @@ import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
+import java.sql.Timestamp;
+
 @RedisHash("userIdx")
 @Getter @ToString @NoArgsConstructor @AllArgsConstructor @Builder
 public class RecentLog {
 
     @Id
     private  Long userIdx;
-    private  PostDto.ListResponse postDto;
+    private  Long postIdx;
+//    private Long timestamp;
 
 }

--- a/src/main/java/com/yapp18/retrospect/service/ListService.java
+++ b/src/main/java/com/yapp18/retrospect/service/ListService.java
@@ -1,5 +1,6 @@
 package com.yapp18.retrospect.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yapp18.retrospect.config.ErrorInfo;
 import com.yapp18.retrospect.domain.post.Post;
@@ -8,16 +9,24 @@ import com.yapp18.retrospect.domain.recent.RecentLog;
 import com.yapp18.retrospect.mapper.PostMapper;
 import com.yapp18.retrospect.web.advice.EntityNullException;
 import com.yapp18.retrospect.web.dto.PostDto;
+import com.yapp18.retrospect.web.dto.RedisRequestDto;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.*;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -26,36 +35,56 @@ public class ListService {
 
     private final PostMapper postMapper;
     private final PostRepository postRepository;
-    private final RedisTemplate<String, PostDto.ListResponse> redisTemplate;
+    private final RedisTemplate<String, RecentLog> redisTemplate;
 
     @Transactional
-    public List<PostDto.ListResponse> findAllPostsByUserIdx(Long userIdx){
-        return postRepository.findAllByUserUserIdxOrderByCreatedAtDesc(userIdx)
+    public List<PostDto.ListResponse> findAllPostsByUserIdx(Long userIdx, Pageable pageable){
+        return postRepository.findAllByUserUserIdxOrderByCreatedAtDesc(userIdx, pageable)
                 .stream().map(post->postMapper.postToListResponse(post, userIdx))
                 .collect(Collectors.toList());
     }
 
-    // 최근 읽은 글 저장
+    // 최근 읽은 글 저장 -> set으로 변경, postIdx?
     @Transactional
     public void saveRecentReadPosts(Long userIdx, Long postIdx){
-        ListOperations<String, PostDto.ListResponse> listOperations = redisTemplate.opsForList();
-        Post post = postRepository.findById(postIdx)
-                .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
-        PostDto.ListResponse postDto = postMapper.postToListResponse(post, userIdx);
-        String key = "userIdx::"+ userIdx;
-        listOperations.leftPush(key, postDto);
-        redisTemplate.expireAt(key, Date.from(ZonedDateTime.now().plusDays(7).toInstant())); // 유효기간 TTL 일주일 설정
+        ZSetOperations<String, RecentLog> zSetOps = redisTemplate.opsForZSet();
+        RecentLog recentLog = RecentLog.builder().userIdx(userIdx).postIdx(postIdx).build();
+        zSetOps.add(setKey(userIdx), recentLog, new java.util.Date().getTime()); // score은 타임스탬프(최신 읽은 순대로 정렬위해)
+        redisTemplate.expireAt(setKey(userIdx), Date.from(ZonedDateTime.now().plusDays(7).toInstant())); // 유효기간 TTL 일주일 설정
     }
 
     // 최근 읽은 글 조회
     @Transactional
     public List<PostDto.ListResponse> findRecentPosts(Long userIdx) {
-        ListOperations<String, PostDto.ListResponse> listOperations = redisTemplate.opsForList();
-        String key = "userIdx::" + userIdx;
-        long size = listOperations.size(key) == null ? 0 : listOperations.size(key); // NPE 체크해야함.
+        ZSetOperations<String, RecentLog> zSetOps = redisTemplate.opsForZSet();
+        // if redis에 key가 있으면
+        ObjectMapper objectMapper = new ObjectMapper(); // linkedHashMap으로 저장된 redis 값들을 List로 변환해줌
+        List<RecentLog> result = objectMapper.convertValue(Objects.requireNonNull(zSetOps.reverseRange(setKey(userIdx), 0, -1)),
+                new TypeReference<List<RecentLog>>() {
+        });
+        return result.stream().map(x -> postMapper.postToListResponse(findPostById(x.getPostIdx()), userIdx)).collect(Collectors.toList());
 
-        return listOperations.range(key, 0, size);
+    }
+    // redis 키 여부 체크
+//    private boolean isKey(String key){
+//
+//    }
+    // redis key 생성
+    private String setKey(Long userIdx){
+        return "userIdx::"+userIdx;
+    }
 
+    // postIdx로 post 엔티티 찾기
+    private Post findPostById(Long postIdx){
+        return postRepository.findById(postIdx)
+                .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
+    }
+
+    // redis에서 value 삭제
+    public void deleteRedisPost(Long userIdx,Long postIdx){
+        ZSetOperations<String, RecentLog> zSetOps = redisTemplate.opsForZSet();
+        RecentLog recentLog = RecentLog.builder().userIdx(userIdx).postIdx(postIdx).build();
+        zSetOps.remove(setKey(userIdx), recentLog);
     }
 
 }

--- a/src/main/java/com/yapp18/retrospect/service/PostService.java
+++ b/src/main/java/com/yapp18/retrospect/service/PostService.java
@@ -164,6 +164,7 @@ public class PostService {
                 .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
         if (isWriter(post.getUser().getUserIdx(), userIdx)){
             postRepository.deleteById(postIdx);
+            listService.deleteRedisPost(userIdx, postIdx); // redis 에서도 삭제
             return true;
         }
         return false;

--- a/src/main/java/com/yapp18/retrospect/web/controller/ListController.java
+++ b/src/main/java/com/yapp18/retrospect/web/controller/ListController.java
@@ -10,6 +10,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,20 +31,20 @@ public class ListController {
 
     @ApiOperation(value = "mypage", notes = "[마이페이지] 내가 쓴 글 보기")
     @GetMapping("")
-    public ResponseEntity<Object> findMyPosts(HttpServletRequest request
-//                                              @RequestParam(value = "page", defaultValue = "0") Long page,
-//                                              @RequestParam(value = "pageSize",defaultValue = "20") Integer pageSize
+    public ResponseEntity<Object> findMyPosts(HttpServletRequest request,
+                                              @RequestParam(value = "page", defaultValue = "0") Long page,
+                                              @RequestParam(value = "pageSize",defaultValue = "20") Integer pageSize
     ){
         Long userIdx = tokenService.getUserIdx(tokenService.getTokenFromRequest(request));
-        List<PostDto.ListResponse> myPostsList = listService.findAllPostsByUserIdx(userIdx);
+        List<PostDto.ListResponse> myPostsList = listService.findAllPostsByUserIdx(userIdx, PageRequest.of(Math.toIntExact(page), pageSize));
         return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.MY_LIST.getResponseMessage(), myPostsList), HttpStatus.OK);
     }
 
-    @ApiOperation(value = "mypage", notes = "[마이페이지] 최근 읽은 글 조회 ")
+    @ApiOperation(value = "mypage", notes = "[마이페이지] 최근 읽은 글 조회")
     @GetMapping("/recent")
     public ResponseEntity<Object> findRecentPosts(HttpServletRequest request){
         Long userIdx = tokenService.getUserIdx(tokenService.getTokenFromRequest(request));
-        return new ResponseEntity<>(ApiDefaultResponse.res(200, "",
+        return new ResponseEntity<>(ApiDefaultResponse.res(200, ResponseMessage.MY_RECENT_LIST.getResponseMessage(),
                 listService.findRecentPosts(userIdx)), HttpStatus.OK);
     }
 

--- a/src/main/java/com/yapp18/retrospect/web/dto/RedisRequestDto.java
+++ b/src/main/java/com/yapp18/retrospect/web/dto/RedisRequestDto.java
@@ -4,28 +4,32 @@ package com.yapp18.retrospect.web.dto;
 import com.yapp18.retrospect.domain.post.Post;
 import com.yapp18.retrospect.domain.recent.RecentLog;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Data
 public class RedisRequestDto {
 
     private Long userIdx;
-    private Post post;
+    private Long postIdx;
+//    private Long timestamp;
 
-//    @Builder
-//    public RedisRequestDto(Long userIdx, Post post){
-//        this.userIdx = userIdx;
-//        this.post = post;
-//    }
-//
+    @Builder
+    public RedisRequestDto(Long userIdx, Long postIdx){
+        this.userIdx = userIdx;
+        this.postIdx = postIdx;
+//        this.timestamp = timestamp;
+    }
+
 //    public RecentLog toRedisHash(){
 //        return RecentLog.builder()
 //                .userIdx(userIdx)
 //                .post(post)
 //                .build();
 //    }
-
+//
 
 }


### PR DESCRIPTION
### 수정사항

- 최근 읽은 글
중복 제거를 위해 list 타입으로 저장하던 로직을 zSet으로 바꾸었습니다.(순서가 있는 set 자료형) 또한 원래 post의 수정이나 삭제가 이루어지는 경우, redis에 저장되어있던 postDto 값이 반영되지 않는다는 문제를 해결하였습니다.

- [x] post 조회결과를 저장하는 것이 아니라 postIdx를 저장하여 조회 시 Mapper로 list 변환
- [x] 회고글 삭제 시 redis 에 저장된 postIdx값도 삭제

또한 ListHashMap으로 조회되어 dto로 값으로 cast가 되지 않는 문제는, ObjectMapper를 통해 List로 변환한 뒤 다시 dto로 변환하는 과정을 거쳤습니다.

- 내가 쓴 글 페이징 추가
cursor 기반으로 페이징되는 메인 및 검색 기능과 달리 내가 쓴 글을 조회할 때는 조회 도중에 글이 추가되거나 삭제될 일이 없으므로, pageable을 사용하여 기본적인 offset 페이징을 달았습니다. 