### PR TITLE
Chore : 회고글 삭제 시 redis에 읽은 글이 있을 때만 삭제

### DIFF
--- a/src/main/java/com/yapp18/retrospect/service/ListService.java
+++ b/src/main/java/com/yapp18/retrospect/service/ListService.java
@@ -69,6 +69,7 @@ public class ListService {
 //    private boolean isKey(String key){
 //
 //    }
+
     // redis key 생성
     private String setKey(Long userIdx){
         return "userIdx::"+userIdx;
@@ -80,11 +81,23 @@ public class ListService {
                 .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
     }
 
+
     // redis에서 value 삭제
     public void deleteRedisPost(Long userIdx,Long postIdx){
         ZSetOperations<String, RecentLog> zSetOps = redisTemplate.opsForZSet();
         RecentLog recentLog = RecentLog.builder().userIdx(userIdx).postIdx(postIdx).build();
         zSetOps.remove(setKey(userIdx), recentLog);
     }
+
+    public boolean isPostsExist(Long userIdx, Long postIdx){
+        ZSetOperations<String, RecentLog> zSetOps = redisTemplate.opsForZSet();
+        RecentLog recentLog = RecentLog.builder().userIdx(userIdx).postIdx(postIdx).build();
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<RecentLog> result = objectMapper.convertValue(Objects.requireNonNull(zSetOps.reverseRange(setKey(userIdx), 0, -1)),
+                new TypeReference<List<RecentLog>>() {
+                });
+        return result.contains(recentLog);
+    }
+
 
 }

--- a/src/main/java/com/yapp18/retrospect/service/PostService.java
+++ b/src/main/java/com/yapp18/retrospect/service/PostService.java
@@ -182,7 +182,7 @@ public class PostService {
                 .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
         if (isWriter(post.getUser().getUserIdx(), userIdx)){
             postRepository.deleteById(postIdx);
-            listService.deleteRedisPost(userIdx, postIdx); // redis 에서도 삭제
+            if (listService.isPostsExist(userIdx, postIdx)) listService.deleteRedisPost(userIdx, postIdx); // redis 에서도 삭제
             return true;
         }
         return false;


### PR DESCRIPTION
### 수정사항

이전에는 post를 삭제할 때 redis에 '최근 읽은 글' 저장도 삭제하도록 했는데,
삭제할 post가 최근 읽은 글로 저장이 안되어있는 경우 오류가 났습니다.
해당 에러를 redis에 post가 있는지 한 번 체크한 뒤 있을 때만 삭제하도록 하였습니다.