### PR TITLE
[최근 읽은 글] 404 에러 및 페이징 수정

### DIFF
--- a/src/main/java/com/yapp18/retrospect/domain/post/Post.java
+++ b/src/main/java/com/yapp18/retrospect/domain/post/Post.java
@@ -90,6 +90,7 @@ public class Post extends BaseTimeEntity {
 
     }
 
+
     public void updatePost(PostDto.updateRequest requestDto){
         this.title = requestDto.getTitle();
         this.category = requestDto.getCategory();

--- a/src/main/java/com/yapp18/retrospect/service/ListService.java
+++ b/src/main/java/com/yapp18/retrospect/service/ListService.java
@@ -2,28 +2,26 @@ package com.yapp18.retrospect.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yapp18.retrospect.config.ErrorInfo;
+import com.yapp18.retrospect.domain.comment.Comment;
+import com.yapp18.retrospect.domain.image.Image;
+import com.yapp18.retrospect.domain.like.Like;
 import com.yapp18.retrospect.domain.post.Post;
 import com.yapp18.retrospect.domain.post.PostRepository;
 import com.yapp18.retrospect.domain.recent.RecentLog;
+import com.yapp18.retrospect.domain.tag.Tag;
+import com.yapp18.retrospect.domain.template.Template;
+import com.yapp18.retrospect.domain.user.User;
 import com.yapp18.retrospect.mapper.PostMapper;
-import com.yapp18.retrospect.web.advice.EntityNullException;
-import com.yapp18.retrospect.web.dto.ApiPagingResultResponse;
 import com.yapp18.retrospect.web.dto.PostDto;
-import com.yapp18.retrospect.web.dto.RedisRequestDto;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.*;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
-import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -57,18 +55,23 @@ public class ListService {
     public List<PostDto.ListResponse> findRecentPosts(Long userIdx, Long page, Integer pageSize) {
         ZSetOperations<String, RecentLog> zSetOps = redisTemplate.opsForZSet();
         // 페이징 start, end 인덱스
+        System.out.println("테스트 ->>>"+ zSetOps.getOperations());
         HashMap<String, Integer> pagingIdx = getPagingIndex(page, pageSize);
         System.out.println("시작"+ pagingIdx.get("start") + " 끝 "+ pagingIdx.get("end"));
         // linkedHashMap 으로 저장된 redis 값들을 List로 변환해줌
-        long size = zSetOps.size(setKey(userIdx));
+//        long size = zSetOps.size(setKey(userIdx));
         ObjectMapper objectMapper = new ObjectMapper();
         List<RecentLog> result = objectMapper.convertValue(Objects.requireNonNull(zSetOps.reverseRange(setKey(userIdx),
                 pagingIdx.get("start"),
                 pagingIdx.get("end"))),
                 new TypeReference<List<RecentLog>>() {
         });
-        return result.stream().map(x -> postMapper.postToListResponse(findPostById(x.getPostIdx()), userIdx)).collect(Collectors.toList())
-                ;
+
+        // if post가 존재하는 경우만 filter
+        List<RecentLog> recentLogList = result.stream().filter(x -> postRepository.findById(x.getPostIdx()).isPresent())
+                .collect(Collectors.toList());
+        return recentLogList.stream().map(x -> postMapper.postToListResponse(findPostById(x.getPostIdx()), userIdx)).collect(Collectors.toList());
+
 
     }
     // redis 키 여부 체크
@@ -83,25 +86,24 @@ public class ListService {
 
     // postIdx로 post 엔티티 찾기
     private Post findPostById(Long postIdx){
-        return postRepository.findById(postIdx)
-                .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
+        return postRepository.findById(postIdx).get();
     }
 
     // redis에서 value 삭제
-    public void deleteRedisPost(Long userIdx,Long postIdx){
-        ZSetOperations<String, RecentLog> zSetOps = redisTemplate.opsForZSet();
-        RecentLog recentLog = RecentLog.builder().userIdx(userIdx).postIdx(postIdx).build();
-        zSetOps.remove(setKey(userIdx), recentLog);
-    }
+//    public void deleteRedisPost(Long userIdx,Long postIdx){
+//        ZSetOperations<String, RecentLog> zSetOps = redisTemplate.opsForZSet();
+//        RecentLog recentLog = RecentLog.builder().userIdx(userIdx).postIdx(postIdx).build();
+//        System.out.println("삭제됨!");
+//        zSetOps.remove(setKey(userIdx), recentLog);
+//    }
 
     // redis에 해당 postIdx 있는지 확인
     public boolean isPostsExist(Long userIdx, Long postIdx){
         ZSetOperations<String, RecentLog> zSetOps = redisTemplate.opsForZSet();
+        System.out.println("redis 전체?" + zSetOps);
         RecentLog recentLog = RecentLog.builder().userIdx(userIdx).postIdx(postIdx).build();
         ObjectMapper objectMapper = new ObjectMapper();
-        List<RecentLog> result = objectMapper.convertValue(Objects.requireNonNull(zSetOps.reverseRange(setKey(userIdx), 0, -1)),
-                new TypeReference<List<RecentLog>>() {
-                });
+        List<RecentLog> result = objectMapper.convertValue(Objects.requireNonNull(zSetOps.reverseRange(setKey(userIdx), 0, -1)), new TypeReference<List<RecentLog>>() {});
         return result.contains(recentLog);
     }
 

--- a/src/main/java/com/yapp18/retrospect/service/ListService.java
+++ b/src/main/java/com/yapp18/retrospect/service/ListService.java
@@ -57,20 +57,18 @@ public class ListService {
         // 페이징 start, end 인덱스
         System.out.println("테스트 ->>>"+ zSetOps.getOperations());
         HashMap<String, Integer> pagingIdx = getPagingIndex(page, pageSize);
-        System.out.println("시작"+ pagingIdx.get("start") + " 끝 "+ pagingIdx.get("end"));
         // linkedHashMap 으로 저장된 redis 값들을 List로 변환해줌
-//        long size = zSetOps.size(setKey(userIdx));
+//        long size = zSetOps.size(setKey(userIdx)); pagingIdx.get("start"), pagingIdx.get("end")
         ObjectMapper objectMapper = new ObjectMapper();
-        List<RecentLog> result = objectMapper.convertValue(Objects.requireNonNull(zSetOps.reverseRange(setKey(userIdx),
-                pagingIdx.get("start"),
-                pagingIdx.get("end"))),
-                new TypeReference<List<RecentLog>>() {
-        });
-
+        List<RecentLog> result = objectMapper.convertValue(Objects.requireNonNull(zSetOps.reverseRange(setKey(userIdx), 0,-1)), new TypeReference<List<RecentLog>>() {});
         // if post가 존재하는 경우만 filter
-        List<RecentLog> recentLogList = result.stream().filter(x -> postRepository.findById(x.getPostIdx()).isPresent())
-                .collect(Collectors.toList());
-        return recentLogList.stream().map(x -> postMapper.postToListResponse(findPostById(x.getPostIdx()), userIdx)).collect(Collectors.toList());
+        List<RecentLog> recentLogList = result.stream().filter(x -> postRepository.findById(x.getPostIdx()).isPresent()).collect(Collectors.toList());
+
+        System.out.println("시작"+ pagingIdx.get("start") + " 끝 "+ pagingIdx.get("end"));
+        return recentLogList.stream()
+                .skip(pagingIdx.get("start"))
+                .limit(pagingIdx.get("end")+1)
+                .map(x -> postMapper.postToListResponse(findPostById(x.getPostIdx()), userIdx)).collect(Collectors.toList());
 
 
     }

--- a/src/main/java/com/yapp18/retrospect/service/PostService.java
+++ b/src/main/java/com/yapp18/retrospect/service/PostService.java
@@ -175,7 +175,10 @@ public class PostService {
                 .orElseThrow(() -> new EntityNullException(ErrorInfo.POST_NULL));
         if (isWriter(post.getUser().getUserIdx(), userIdx)){
             postRepository.deleteById(postIdx);
-            if (listService.isPostsExist(userIdx, postIdx)) listService.deleteRedisPost(userIdx, postIdx); // redis 에서도 삭제
+//            if (listService.isPostsExist(userIdx, postIdx)) {
+//                // ** redis에 있는 모든...어쩌구....
+//                listService.deleteRedisPost(userIdx, postIdx); // redis 에서도 삭제
+//            }
             return true;
         }
         return false;


### PR DESCRIPTION
### 수정사항

**- 404 에러**
테스트 환경에서 회고글을 삭제할 때 해당 작성자의 redis Key에서만 postIdx를 삭제했음.
만약 회고글 삭제로 redis를 처리하려면, 한 회고글을 지울 때마다 그 회고글을 읽은 n개의 key에 접근하여 다 지워줘야한다는 문제가 생김.

-> redis에서 key로 조회한 결과를 isPresent()로 filter 걸어서 "Redis에 저장된 최근 읽은 글 postIdx 중, 유효한 postIdx 값"만 가진 recentLogList 생성

**- 페이징**
이전 페이징 방식은 redis에서 key값으로 zSet을 가져올 때 range값으로 페이징을 해왔다. 하지만 그렇게 되면 8개씩 가져온 목록에서 filter을 걸게 되어 8개가 아니라 5개...2개...로 바뀔 수 있다는 문제가 생김.

-> filter 결과인 recentLogList에서 stream의 skip, limit 을 사용하여 리스트를 페이징
